### PR TITLE
Fix ceph ansible

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -22,7 +22,7 @@ echo "export 'no_proxy=$no_proxy'" >> /etc/profile.d/envvar.sh
 
 . /etc/profile.d/envvar.sh
 
-mkdir /etc/systemd/system/docker.service.d
+mkdir -p /etc/systemd/system/docker.service.d
 echo "[Service]" | sudo tee -a /etc/systemd/system/docker.service.d/http-proxy.conf &>/dev/null
 echo "Environment=\\\"no_proxy=$no_proxy\\\" \\\"http_proxy=$http_proxy\\\" \\\"https_proxy=$https_proxy\\\"" | sudo tee -a /etc/systemd/system/docker.service.d/http-proxy.conf &>/dev/null
 sudo systemctl daemon-reload

--- a/ansible/group_vars/all
+++ b/ansible/group_vars/all
@@ -21,7 +21,7 @@ dummy:
 
 # COMMUNITY VERSION
 ceph_stable: true # use ceph stable branch
-ceph_stable_key: https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc
+ceph_stable_key: /tmp/cephstable.asc
 ceph_stable_release: hammer # ceph stable release
 
 # This option is needed for _both_ stable and dev version, so please always fill the right version

--- a/ansible/roles/ceph-common/defaults/main.yml
+++ b/ansible/roles/ceph-common/defaults/main.yml
@@ -18,7 +18,7 @@ restapi_group_name: restapis
 
 # COMMUNITY VERSION
 ceph_stable: true # use ceph stable branch
-ceph_stable_key: https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc
+ceph_stable_key: /tmp/cephstable.asc
 ceph_stable_release: hammer # ceph stable release
 
 # This option is needed for _both_ stable and dev version, so please always fill the right version

--- a/ansible/roles/ceph-common/tasks/install_on_redhat.yml
+++ b/ansible/roles/ceph-common/tasks/install_on_redhat.yml
@@ -10,9 +10,15 @@
     - yum-plugin-priorities.noarch
     - epel-release
 
+- name: write Ceph stable repository key
+  copy: >
+    src=cephstable.asc
+    dest=/tmp/cephstable.asc
+  when: ceph_stable
+
 - name: install the Ceph stable repository key
   rpm_key: >
-    key={{ ceph_stable_key }}
+    key=/tmp/cephstable.asc
     state=present
   when: ceph_stable
 
@@ -37,6 +43,10 @@
 - name: add Ceph stable repository
   yum: name=http://ceph.com/rpm-{{ ceph_stable_release }}/{{ ceph_stable_redhat_distro }}/noarch/ceph-release-1-0.{{ ceph_stable_redhat_distro|replace('rhel', 'el') }}.noarch.rpm
   changed_when: false
+  when: ceph_stable
+
+- name: edit Ceph stable repository to eliminate GPG check
+  shell: "sed -i 's/gpgcheck=1/gpgcheck=0/g' /etc/yum.repos.d/ceph.repo"
   when: ceph_stable
 
 - name: add Ceph development repository

--- a/ansible/roles/ceph-radosgw/templates/ceph-extra.repo
+++ b/ansible/roles/ceph-radosgw/templates/ceph-extra.repo
@@ -7,7 +7,7 @@ enabled=1
 priority=2
 gpgcheck=1
 type=rpm-md
-gpgkey=https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc
+gpgkey=/tmp/cephstable.asc
 
 {% if (redhat_distro_ceph_extra != "centos6.4" and redhat_distro_ceph_extra !=  "rhel6.4" and redhat_distro_ceph_extra !=  "rhel6.5") %}
 [ceph-extras-noarch]
@@ -17,7 +17,7 @@ enabled=1
 priority=2
 gpgcheck=1
 type=rpm-md
-gpgkey=https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc
+gpgkey=/tmp/cephstable.asc
 {% endif %}
 
 [ceph-extras-source]
@@ -27,4 +27,4 @@ enabled=1
 priority=2
 gpgcheck=1
 type=rpm-md
-gpgkey=https://ceph.com/git/?p=ceph.git;a=blob_plain;f=keys/release.asc
+gpgkey=/tmp/cephstable.asc


### PR DESCRIPTION
This provides a number of fixes to the build to make it more reliable. In particular, the RPM that ceph uses to install its repository data relies on a URL for the GPG key which is not always available. We try to provide multiple solutions here to resolve the problem.