### PR TITLE
Rate limit io

### DIFF
--- a/cephdriver/cephdriver_test.go
+++ b/cephdriver/cephdriver_test.go
@@ -56,7 +56,11 @@ func (s cephSuite) TestMountUnmountVolume(c *C) {
 	volumeSpec.Remove()
 
 	c.Assert(volumeSpec.Create("mkfs.ext4 -m0 %"), IsNil)
-	c.Assert(volumeSpec.Mount("ext4"), IsNil)
+	ms, err := volumeSpec.Mount("ext4")
+	c.Assert(err, IsNil)
+	c.Assert(ms.DevMajor, Equals, uint(252))
+	c.Assert(ms.DevMinor, Equals, uint(0))
+	c.Assert(strings.HasPrefix(ms.DeviceName, "/dev/rbd"), Equals, true)
 	s.readWriteTest(c, "/mnt/ceph/rbd/pithos1234")
 	c.Assert(volumeSpec.Unmount(), IsNil)
 	c.Assert(volumeSpec.Remove(), IsNil)
@@ -87,7 +91,8 @@ func (s cephSuite) TestRepeatedMountUnmount(c *C) {
 	volumeSpec := NewCephDriver().NewVolume("rbd", "pithos1234", 10)
 	c.Assert(volumeSpec.Create("mkfs.ext4 -m0 %"), IsNil)
 	for i := 0; i < 10; i++ {
-		c.Assert(volumeSpec.Mount("ext4"), IsNil)
+		_, err := volumeSpec.Mount("ext4")
+		c.Assert(err, IsNil)
 		s.readWriteTest(c, "/mnt/ceph/rbd/pithos1234")
 		c.Assert(volumeSpec.Unmount(), IsNil)
 	}

--- a/config/volume.go
+++ b/config/volume.go
@@ -20,12 +20,21 @@ type VolumeConfig struct {
 
 // VolumeOptions comprises the optional paramters a volume can accept.
 type VolumeOptions struct {
-	Pool         string         `json:"pool" merge:"pool"`
-	Size         uint64         `json:"size" merge:"size"`
-	UseSnapshots bool           `json:"snapshots" merge:"snapshots"`
-	Snapshot     SnapshotConfig `json:"snapshot"`
-	FileSystem   string         `json:"filesystem" merge:"filesystem"`
-	Ephemeral    bool           `json:"ephemeral,omitempty" merge:"ephemeral"`
+	Pool         string          `json:"pool" merge:"pool"`
+	Size         uint64          `json:"size" merge:"size"`
+	UseSnapshots bool            `json:"snapshots" merge:"snapshots"`
+	Snapshot     SnapshotConfig  `json:"snapshot"`
+	FileSystem   string          `json:"filesystem" merge:"filesystem"`
+	Ephemeral    bool            `json:"ephemeral,omitempty" merge:"ephemeral"`
+	RateLimit    RateLimitConfig `json:"rate-limit,omitempty"`
+}
+
+// RateLimitConfig is the configuration for limiting the rate of disk access.
+type RateLimitConfig struct {
+	WriteIOPS uint   `json:"write-iops" merge:"rate-limit.write.iops"`
+	ReadIOPS  uint   `json:"read-iops" merge:"rate-limit.read.iops"`
+	WriteBPS  uint64 `json:"write-bps" merge:"rate-limit.write.bps"`
+	ReadBPS   uint64 `json:"read-bps" merge:"rate-limit.read.bps"`
 }
 
 // SnapshotConfig is the configuration for snapshots.

--- a/docs/4_configuration.md
+++ b/docs/4_configuration.md
@@ -36,8 +36,14 @@ Here is an example:
       "frequency": "30m",
       "keep": 20
     },
-		"filesystem": "btrfs",
+    "filesystem": "btrfs",
     "ephemeral": false,
+    "rate-limit": {
+      "write-iops": 1000,
+      "read-iops": 1000,
+      "write-bps": 100000000,
+      "read-bps": 100000000
+    }
   },
 	"filesystems": {
 		"btrfs": "mkfs.btrfs %",
@@ -59,6 +65,11 @@ Let's go through what these parameters mean.
     * `keep`: how many snapshots to keep
 	* `filesystem`: which filesystem to use. See below for how this works.
   * `ephemeral`: when `true`, deletes volumes upon `docker volume rm`.
+  * `rate-limit`: sub-level configuration for rate limiting.
+    * `write-iops`: Write IOPS
+    * `read-iops`: Read IOPS
+    * `read-bps`: Read b/s
+    * `write-bps`: Write b/s
 * `filesystems`: Provides a map of filesystem -> command for volumes to use in
 	the `filesystem` option.
 	* Commands are run when the filesystem is specified and the volume has not
@@ -99,3 +110,7 @@ The options are as follows:
 * `filesystem`: the named filesystem to create. See the JSON Configuration
   section for more information on this.
 * `ephemeral`: delete this volume after `docker volume rm` occurs.
+* `rate-limit.write.iops`: Write IOPS
+* `rate-limit.read.iops`: Read IOPS
+* `rate-limit.read.bps`: Read b/s
+* `rate-limit.write.bps`: Write b/s

--- a/volplugin/cgroup.go
+++ b/volplugin/cgroup.go
@@ -1,0 +1,40 @@
+package volplugin
+
+import (
+	"fmt"
+	"io/ioutil"
+
+	"github.com/contiv/volplugin/cephdriver"
+	"github.com/contiv/volplugin/config"
+)
+
+// FIXME find a better place for these
+const (
+	writeIOPSFile = "/sys/fs/cgroup/blkio/blkio.throttle.write_iops_device"
+	readIOPSFile  = "/sys/fs/cgroup/blkio/blkio.throttle.read_iops_device"
+	writeBPSFile  = "/sys/fs/cgroup/blkio/blkio.throttle.write_bps_device"
+	readBPSFile   = "/sys/fs/cgroup/blkio/blkio.throttle.read_bps_device"
+)
+
+func makeLimit(mc *cephdriver.CephMount, limit uint64) []byte {
+	return []byte(fmt.Sprintf("%d:%d %d\n", mc.DevMajor, mc.DevMinor, limit))
+}
+
+func applyCGroupRateLimit(vc *config.VolumeConfig, mc *cephdriver.CephMount) error {
+	opMap := map[string]uint64{
+		writeIOPSFile: uint64(vc.Options.RateLimit.WriteIOPS),
+		readIOPSFile:  uint64(vc.Options.RateLimit.ReadIOPS),
+		writeBPSFile:  vc.Options.RateLimit.WriteBPS,
+		readBPSFile:   vc.Options.RateLimit.ReadBPS,
+	}
+
+	for fn, val := range opMap {
+		if val > 0 {
+			if err := ioutil.WriteFile(fn, makeLimit(mc, val), 0600); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/volplugin/handlers.go
+++ b/volplugin/handlers.go
@@ -193,8 +193,14 @@ func mount(master, host string) func(http.ResponseWriter, *http.Request) {
 			return
 		}
 
-		if err := driver.NewVolume(volConfig.Options.Pool, joinPath(tenant, name), volConfig.Options.Size).Mount(volConfig.Options.FileSystem); err != nil {
+		mc, err := driver.NewVolume(volConfig.Options.Pool, joinPath(tenant, name), volConfig.Options.Size).Mount(volConfig.Options.FileSystem)
+		if err != nil {
 			httpError(w, "Volume could not be mounted", err)
+			return
+		}
+
+		if err := applyCGroupRateLimit(volConfig, mc); err != nil {
+			httpError(w, "Applying cgroups", err)
 			return
 		}
 


### PR DESCRIPTION
This implements rate limiting. It comes in three distinct parts:

* config -- parameters, json configuration
* cephdriver -- code to gather device major/minor numbers and report it (and other critical data) with the mount.
* volplugin -- code to implement the cgroups file writes to the blkio controller on mount.

the blkio directives we're utilizing automatically vaporize on a umount, which is what we do any time the container is stopped. Therefore, applying them each time becomes idempotent, even with multiple hosts and mounts going on at the same time.

The tests verify the files are written to with magic numbers; they are high enough in value that they allow the fsck to proceed. :)

the major/minor device number code is pretty linux specific, and probably bad.
