### PR TITLE
config,volmaster,volplugin: first pass at TTL support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ unit-test-nocoverage:
 unit-test-nocoverage-host: golint-host govet-host
 	HOST_TEST=1 GOGC=1000 godep go test -v ./... -check.v
 
-build: golint
+build: golint govet
 	vagrant ssh mon0 -c 'sudo -i sh -c "cd $(GUESTGOPATH); make run-build"'
 
 run:

--- a/config/use_test.go
+++ b/config/use_test.go
@@ -2,6 +2,9 @@ package config
 
 import (
 	"sort"
+	"time"
+
+	"github.com/coreos/etcd/client"
 
 	. "gopkg.in/check.v1"
 )
@@ -46,4 +49,15 @@ func (s *configSuite) TestUseCRUD(c *C) {
 
 	sort.Strings(mounts)
 	c.Assert([]string{"tenant1/quux", "tenant2/baz"}, DeepEquals, mounts)
+}
+
+func (s *configSuite) TestUseCRUDWithTTL(c *C) {
+	c.Assert(s.tlc.PublishUseWithTTL(testUseConfigs["basic"], 5*time.Second, client.PrevNoExist), IsNil)
+	use, err := s.tlc.GetUse(testUseVolumeConfigs["basic"])
+	c.Assert(err, IsNil)
+	c.Assert(use, DeepEquals, testUseConfigs["basic"])
+	time.Sleep(10 * time.Second)
+	use, err = s.tlc.GetUse(testUseVolumeConfigs["basic"])
+	c.Assert(err, NotNil)
+	c.Assert(use, IsNil)
 }

--- a/systemtests/util_test.go
+++ b/systemtests/util_test.go
@@ -174,7 +174,7 @@ func stopVolsupervisor(node utils.TestbedNode) error {
 
 func startVolmaster(node utils.TestbedNode) error {
 	log.Infof("Starting the volmaster on %s", node.GetName())
-	_, err := node.RunCommandBackground("sudo -E nohup `which volmaster` --debug </dev/null &>/tmp/volmaster.log &")
+	_, err := node.RunCommandBackground("sudo -E nohup `which volmaster` --debug --ttl 5 </dev/null &>/tmp/volmaster.log &")
 	log.Infof("Waiting for volmaster startup")
 	time.Sleep(10 * time.Millisecond)
 	return err
@@ -191,7 +191,7 @@ func startVolplugin(node utils.TestbedNode) error {
 
 	// FIXME this is hardcoded because it's simpler. If we move to
 	// multimaster or change the monitor subnet, we will have issues.
-	_, err := node.RunCommandBackground("sudo -E `which volplugin` --debug &>/tmp/volplugin.log &")
+	_, err := node.RunCommandBackground("sudo -E `which volplugin` --debug --ttl 5 &>/tmp/volplugin.log &")
 	return err
 }
 
@@ -234,7 +234,7 @@ func (s *systemtestSuite) clearVolumes() error {
 
 func (s *systemtestSuite) clearRBD() error {
 	log.Info("Clearing rbd images")
-	if out, err := s.vagrant.GetNode("mon0").RunCommandWithOutput("set -e; for img in $(sudo rbd showmapped | tail -n +2 | awk \"{ print \\$5 }\"); do sudo rbd unmap $img; done"); err != nil {
+	if out, err := s.vagrant.GetNode("mon0").RunCommandWithOutput("set -e; for img in $(sudo rbd showmapped | tail -n +2 | awk \"{ print \\$5 }\"); do sudo umount $img; sudo rbd unmap $img; done"); err != nil {
 		log.Info(out)
 		return err
 	}

--- a/volmaster/volmaster/cli.go
+++ b/volmaster/volmaster/cli.go
@@ -22,7 +22,7 @@ func start(ctx *cli.Context) {
 		log.Fatal(err)
 	}
 
-	volmaster.Daemon(cfg, ctx.Bool("debug"), ctx.String("listen"))
+	volmaster.Daemon(cfg, ctx.Int("ttl"), ctx.Bool("debug"), ctx.String("listen"))
 }
 
 func main() {
@@ -51,6 +51,11 @@ func main() {
 			Name:  "etcd",
 			Usage: "URL for etcd",
 			Value: &cli.StringSlice{"http://localhost:2379"},
+		},
+		cli.IntFlag{
+			Name:  "ttl",
+			Usage: "Set ttl of written locks; in seconds",
+			Value: 300,
 		},
 	}
 

--- a/volplugin/volplugin.go
+++ b/volplugin/volplugin.go
@@ -10,10 +10,21 @@ import (
 	"strings"
 
 	log "github.com/Sirupsen/logrus"
+	"github.com/contiv/volplugin/config"
+	"github.com/contiv/volplugin/storage/backend/ceph"
 	"github.com/gorilla/mux"
 )
 
 const basePath = "/run/docker/plugins"
+
+// DaemonConfig is the top-level configuration for the daemon. It is used by
+// the cli package in volplugin/volplugin.
+type DaemonConfig struct {
+	Debug  bool
+	TTL    int
+	Master string
+	Host   string
+}
 
 // VolumeRequest is taken from
 // https://github.com/calavera/docker-volume-api/blob/master/api.go#L23
@@ -30,7 +41,11 @@ type VolumeResponse struct {
 }
 
 // Daemon starts the volplugin service.
-func Daemon(debug bool, master, host string) error {
+func (dc *DaemonConfig) Daemon() error {
+	if err := dc.updateMounts(); err != nil {
+		return err
+	}
+
 	driverPath := path.Join(basePath, "volplugin.sock")
 	if err := os.Remove(driverPath); err != nil && !os.IsNotExist(err) {
 		return err
@@ -44,23 +59,23 @@ func Daemon(debug bool, master, host string) error {
 		return err
 	}
 
-	if debug {
+	if dc.Debug {
 		log.SetLevel(log.DebugLevel)
 	}
 
-	http.Serve(l, configureRouter(debug, master, host))
+	http.Serve(l, dc.configureRouter())
 	return l.Close()
 }
 
-func configureRouter(debug bool, master, host string) *mux.Router {
+func (dc *DaemonConfig) configureRouter() *mux.Router {
 	var routeMap = map[string]func(http.ResponseWriter, *http.Request){
 		"/Plugin.Activate":      activate,
 		"/Plugin.Deactivate":    nilAction,
-		"/VolumeDriver.Create":  create(master),
-		"/VolumeDriver.Remove":  remove(master),
-		"/VolumeDriver.Path":    getPath(master),
-		"/VolumeDriver.Mount":   mount(master, host),
-		"/VolumeDriver.Unmount": unmount(master),
+		"/VolumeDriver.Create":  create(dc.Master),
+		"/VolumeDriver.Remove":  remove(dc.Master),
+		"/VolumeDriver.Path":    getPath(dc.Master),
+		"/VolumeDriver.Mount":   mount(dc.Master, dc.Host, dc.TTL),
+		"/VolumeDriver.Unmount": unmount(dc.Master, dc.Host),
 	}
 
 	router := mux.NewRouter()
@@ -68,10 +83,10 @@ func configureRouter(debug bool, master, host string) *mux.Router {
 
 	for key, value := range routeMap {
 		parts := strings.SplitN(key, ".", 2)
-		s.HandleFunc(key, logHandler(parts[1], debug, value))
+		s.HandleFunc(key, logHandler(parts[1], dc.Debug, value))
 	}
 
-	if debug {
+	if dc.Debug {
 		s.HandleFunc("{action:.*}", action)
 	}
 
@@ -94,4 +109,48 @@ func logHandler(name string, debug bool, actionFunc func(http.ResponseWriter, *h
 
 		actionFunc(w, r)
 	}
+}
+
+func (dc *DaemonConfig) updateMounts() error {
+	cd := ceph.NewDriver()
+	mounts, err := cd.Mounted()
+	if err != nil {
+		return err
+	}
+
+	for _, mount := range mounts {
+		parts := strings.Split(mount.Volume.Name, "/")
+		if len(parts) != 2 {
+			log.Warnf("Invalid volume named %q in ceph scan: skipping refresh", mount.Volume.Name)
+			continue
+		}
+
+		log.Infof("Refreshing existing mount for %q", mount.Volume.Name)
+
+		volConfig, err := requestVolumeConfig(dc.Master, parts[0], parts[1])
+		switch err {
+		case errVolumeNotFound:
+			log.Warnf("Volume %q not found in database, skipping")
+			continue
+		case errVolumeResponse:
+			log.Fatalf("Volmaster could not be contacted; aborting volplugin.")
+		}
+
+		payload := &config.UseConfig{
+			Hostname: dc.Host,
+			Volume:   volConfig,
+		}
+
+		if err := reportMount(dc.Master, payload); err != nil {
+			if err := reportMountStatus(dc.Master, payload); err != nil {
+				// FIXME everything is effed up. what should we really be doing here?
+				return err
+			}
+		}
+
+		stop := addStopChan(mount.Volume.Name)
+		go heartbeatMount(dc.Master, dc.TTL, payload, stop)
+	}
+
+	return nil
 }

--- a/volplugin/volplugin/cli.go
+++ b/volplugin/volplugin/cli.go
@@ -40,6 +40,11 @@ func main() {
 			EnvVar: "HOSTLABEL",
 			Value:  host,
 		},
+		cli.IntFlag{
+			Name:  "ttl",
+			Usage: "Set the timeout for refreshing mount point data to the volmaster",
+			Value: 300,
+		},
 	}
 	app.Action = run
 
@@ -50,5 +55,15 @@ func main() {
 }
 
 func run(ctx *cli.Context) {
-	volplugin.Daemon(ctx.Bool("debug"), ctx.String("master"), ctx.String("host-label"))
+	dc := &volplugin.DaemonConfig{
+		Debug:  ctx.Bool("debug"),
+		TTL:    ctx.Int("ttl"),
+		Master: ctx.String("master"),
+		Host:   ctx.String("host-label"),
+	}
+
+	if err := dc.Daemon(); err != nil {
+		fmt.Fprintf(os.Stderr, "\nError: %v\n\n", err)
+		os.Exit(1)
+	}
 }


### PR DESCRIPTION
@mapuri @unclejack @jainvipin 

This implements TTL support or crash-resistant recovery from #76. It implements this by using etcd TTL support to automatically expire records when the host does not report back.

The host may re-acquire the lock on volplugin restart if if the lock has not be re-acquired.

The third case where volplugin is not restarted (therefore the locks are not refreshed) and the mounts are not cleared, this will be settled by another PR which will introduce a "maintenance mode" that people can run to perform host operations without being able to acquire mounts and whatnot. This allows people to keep the locks in place while performing maintenance.

This is a large, critical change so please PTAL (all of you) and review carefully. @shaleman I know you don't work on this project but I'd love to hear your input as well.