### PR TITLE
More tests

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"path"
 
+	"github.com/alecthomas/units"
 	"github.com/coreos/etcd/client"
 	"golang.org/x/net/context"
 )
@@ -12,6 +13,10 @@ const (
 	rootVolume = "volumes"
 	rootUse    = "users"
 	rootTenant = "tenants"
+)
+
+var (
+	quux = units.Mebibyte
 )
 
 var defaultPaths = []string{rootVolume, rootUse, rootTenant}

--- a/config/tenant.go
+++ b/config/tenant.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"encoding/json"
-	"fmt"
 	"path"
 
 	"github.com/coreos/etcd/client"
@@ -73,14 +72,7 @@ func (c *TopLevelConfig) GetTenant(name string) (*TenantConfig, error) {
 		return nil, err
 	}
 
-	if err := tc.DefaultVolumeOptions.computeSize(); err != nil {
-		return nil, err
-	}
-
-	if err := tc.DefaultVolumeOptions.Validate(); err != nil {
-		return nil, err
-	}
-
+	err = tc.Validate()
 	return tc, err
 }
 
@@ -90,10 +82,6 @@ func (c *TopLevelConfig) ListTenants() ([]string, error) {
 	resp, err := c.etcdClient.Get(context.Background(), c.prefixed(rootTenant), &client.GetOptions{Recursive: true, Sort: true})
 	if err != nil {
 		return nil, err
-	}
-
-	if resp.Node == nil {
-		return nil, fmt.Errorf("Tenant's root is missing")
 	}
 
 	tenants := []string{}

--- a/config/tenant_test.go
+++ b/config/tenant_test.go
@@ -1,6 +1,11 @@
 package config
 
-import . "gopkg.in/check.v1"
+import (
+	"os/exec"
+	"time"
+
+	. "gopkg.in/check.v1"
+)
 
 var testTenantConfigs = map[string]*TenantConfig{
 	"basic": {
@@ -13,6 +18,24 @@ var testTenantConfigs = map[string]*TenantConfig{
 		FileSystems: defaultFilesystems,
 	},
 	"basic2": {
+		DefaultVolumeOptions: VolumeOptions{
+			Pool:         "rbd",
+			Size:         "20MB",
+			UseSnapshots: false,
+			FileSystem:   defaultFilesystem,
+		},
+		FileSystems: defaultFilesystems,
+	},
+	"untouchedwithzerosize": {
+		DefaultVolumeOptions: VolumeOptions{
+			Pool:         "rbd",
+			Size:         "0",
+			UseSnapshots: false,
+			FileSystem:   defaultFilesystem,
+		},
+		FileSystems: defaultFilesystems,
+	},
+	"nilfs": {
 		DefaultVolumeOptions: VolumeOptions{
 			Pool:         "rbd",
 			Size:         "20MB",
@@ -50,6 +73,18 @@ var testTenantConfigs = map[string]*TenantConfig{
 			Size:         "not a number",
 			UseSnapshots: false,
 			FileSystem:   defaultFilesystem,
+		},
+		FileSystems: defaultFilesystems,
+	},
+	"badsnaps": {
+		DefaultVolumeOptions: VolumeOptions{
+			Size:         "10M",
+			UseSnapshots: true,
+			FileSystem:   defaultFilesystem,
+			Snapshot: SnapshotConfig{
+				Keep:      0,
+				Frequency: "",
+			},
 		},
 		FileSystems: defaultFilesystems,
 	},
@@ -92,13 +127,59 @@ func (s *configSuite) TestBasicTenant(c *C) {
 }
 
 func (s *configSuite) TestTenantValidate(c *C) {
-	for _, key := range []string{"basic", "basic2"} {
+	for _, key := range []string{"basic", "basic2", "nilfs"} {
 		c.Assert(testTenantConfigs[key].Validate(), IsNil)
 	}
 
+	// FIXME: ensure the default filesystem option is set when validate is called.
+	//        honestly, this both a pretty lousy way to do it and test it, we should do
+	//        something better.
+	c.Assert(testTenantConfigs["nilfs"].FileSystems, DeepEquals, map[string]string{defaultFilesystem: "mkfs.ext4 -m0 %"})
+
+	c.Assert(testTenantConfigs["untouchedwithzerosize"].Validate(), NotNil)
 	c.Assert(testTenantConfigs["nopool"].Validate(), NotNil)
 	c.Assert(testTenantConfigs["badsize"].Validate(), NotNil)
 	c.Assert(testTenantConfigs["badsize2"].Validate(), NotNil)
 	_, err := testTenantConfigs["badsize3"].DefaultVolumeOptions.ActualSize()
+	c.Assert(err, NotNil)
+}
+
+func (s *configSuite) TestTenantBadPublish(c *C) {
+	for _, key := range []string{"badsize", "badsize2", "badsize3", "nopool", "badsnaps"} {
+		c.Assert(s.tlc.PublishTenant("test", testTenantConfigs[key]), NotNil)
+	}
+}
+
+func (s *configSuite) TestTenantPublishEtcdDown(c *C) {
+	defer time.Sleep(1 * time.Second)
+	defer func() {
+		// I have ABSOLUTELY no idea why CombinedOutput() is required here, but it is.
+		_, err := exec.Command("/bin/sh", "-c", "sudo systemctl restart etcd").CombinedOutput()
+		c.Assert(err, IsNil)
+	}()
+
+	c.Assert(exec.Command("/bin/sh", "-c", "sudo systemctl start etcd").Run(), IsNil)
+	c.Assert(exec.Command("/bin/sh", "-c", "sudo systemctl stop etcd").Run(), IsNil)
+	time.Sleep(1 * time.Second)
+
+	for _, key := range []string{"basic", "basic2"} {
+		c.Assert(s.tlc.PublishTenant("test", testTenantConfigs[key]), NotNil)
+	}
+}
+
+func (s *configSuite) TestTenantListEtcdDown(c *C) {
+	defer time.Sleep(1 * time.Second)
+	defer func() {
+		// I have ABSOLUTELY no idea why CombinedOutput() is required here, but it is.
+		_, err := exec.Command("/bin/sh", "-c", "sudo systemctl restart etcd").CombinedOutput()
+		c.Assert(err, IsNil)
+	}()
+
+	c.Assert(exec.Command("/bin/sh", "-c", "sudo systemctl start etcd").Run(), IsNil)
+	c.Assert(exec.Command("/bin/sh", "-c", "sudo systemctl stop etcd").Run(), IsNil)
+	time.Sleep(1 * time.Second)
+
+	_, err := s.tlc.ListTenants()
+
 	c.Assert(err, NotNil)
 }

--- a/config/tenant_test.go
+++ b/config/tenant_test.go
@@ -29,6 +29,30 @@ var testTenantConfigs = map[string]*TenantConfig{
 		},
 		FileSystems: defaultFilesystems,
 	},
+	"badsize": {
+		DefaultVolumeOptions: VolumeOptions{
+			Size:         "0",
+			UseSnapshots: false,
+			FileSystem:   defaultFilesystem,
+		},
+		FileSystems: defaultFilesystems,
+	},
+	"badsize2": {
+		DefaultVolumeOptions: VolumeOptions{
+			Size:         "10M",
+			UseSnapshots: false,
+			FileSystem:   defaultFilesystem,
+		},
+		FileSystems: defaultFilesystems,
+	},
+	"badsize3": {
+		DefaultVolumeOptions: VolumeOptions{
+			Size:         "not a number",
+			UseSnapshots: false,
+			FileSystem:   defaultFilesystem,
+		},
+		FileSystems: defaultFilesystems,
+	},
 }
 
 func (s *configSuite) TestBasicTenant(c *C) {
@@ -73,4 +97,8 @@ func (s *configSuite) TestTenantValidate(c *C) {
 	}
 
 	c.Assert(testTenantConfigs["nopool"].Validate(), NotNil)
+	c.Assert(testTenantConfigs["badsize"].Validate(), NotNil)
+	c.Assert(testTenantConfigs["badsize2"].Validate(), NotNil)
+	_, err := testTenantConfigs["badsize3"].DefaultVolumeOptions.ActualSize()
+	c.Assert(err, NotNil)
 }

--- a/config/use_test.go
+++ b/config/use_test.go
@@ -49,6 +49,12 @@ func (s *configSuite) TestUseCRUD(c *C) {
 
 	sort.Strings(mounts)
 	c.Assert([]string{"tenant1/quux", "tenant2/baz"}, DeepEquals, mounts)
+
+	basicTmp := *testUseConfigs["basic"]
+	basicTmp.Hostname = "quux"
+
+	c.Assert(s.tlc.RemoveUse(&basicTmp, false), NotNil)
+	c.Assert(s.tlc.RemoveUse(&basicTmp, true), IsNil)
 }
 
 func (s *configSuite) TestUseCRUDWithTTL(c *C) {
@@ -60,4 +66,15 @@ func (s *configSuite) TestUseCRUDWithTTL(c *C) {
 	use, err = s.tlc.GetUse(testUseVolumeConfigs["basic"])
 	c.Assert(err, NotNil)
 	c.Assert(use, IsNil)
+
+	c.Assert(s.tlc.PublishUseWithTTL(testUseConfigs["basic"], 5*time.Second, client.PrevNoExist), IsNil)
+	c.Assert(s.tlc.PublishUseWithTTL(testUseConfigs["basic"], 5*time.Second, client.PrevExist), IsNil)
+	c.Assert(s.tlc.PublishUseWithTTL(testUseConfigs["basic2"], 5*time.Second, client.PrevNoExist), IsNil)
+}
+
+func (s *configSuite) TestUseListEtcdDown(c *C) {
+	stopStartEtcd(c, func() {
+		_, err := s.tlc.ListUses()
+		c.Assert(err, NotNil)
+	})
 }

--- a/config/util_test.go
+++ b/config/util_test.go
@@ -1,0 +1,22 @@
+package config
+
+import (
+	"os/exec"
+	"time"
+
+	. "gopkg.in/check.v1"
+)
+
+func stopStartEtcd(c *C, f func()) {
+	defer time.Sleep(1 * time.Second)
+	defer func() {
+		// I have ABSOLUTELY no idea why CombinedOutput() is required here, but it is.
+		_, err := exec.Command("/bin/sh", "-c", "sudo systemctl restart etcd").CombinedOutput()
+		c.Assert(err, IsNil)
+	}()
+
+	c.Assert(exec.Command("/bin/sh", "-c", "sudo systemctl start etcd").Run(), IsNil)
+	c.Assert(exec.Command("/bin/sh", "-c", "sudo systemctl stop etcd").Run(), IsNil)
+	time.Sleep(1 * time.Second)
+	f()
+}

--- a/config/volume.go
+++ b/config/volume.go
@@ -218,7 +218,14 @@ func (vo *VolumeOptions) Validate() error {
 	}
 
 	if vo.actualSize == 0 {
-		return fmt.Errorf("Config for tenant has a zero size")
+		actualSize, err := vo.ActualSize()
+		if err != nil {
+			return err
+		}
+
+		if actualSize == 0 {
+			return fmt.Errorf("Config for tenant has a zero size")
+		}
 	}
 
 	if vo.UseSnapshots && (vo.Snapshot.Frequency == "" || vo.Snapshot.Keep == 0) {

--- a/config/volume.go
+++ b/config/volume.go
@@ -85,10 +85,6 @@ func (c *TopLevelConfig) CreateVolume(rc RequestCreate) (*VolumeConfig, error) {
 
 // PublishVolume writes a volume to etcd.
 func (c *TopLevelConfig) PublishVolume(vc *VolumeConfig) error {
-	if err := vc.Options.computeSize(); err != nil {
-		return err
-	}
-
 	if err := vc.Validate(); err != nil {
 		return err
 	}
@@ -140,10 +136,6 @@ func (c *TopLevelConfig) GetVolume(tenant, name string) (*VolumeConfig, error) {
 	ret := &VolumeConfig{}
 
 	if err := json.Unmarshal([]byte(resp.Node.Value), ret); err != nil {
-		return nil, err
-	}
-
-	if err := ret.Options.computeSize(); err != nil {
 		return nil, err
 	}
 

--- a/systemtests/volcli_test.go
+++ b/systemtests/volcli_test.go
@@ -134,10 +134,6 @@ func (s *systemtestSuite) TestVolCLIUse(c *C) {
 	id, err := s.docker("run -itd -v tenant1/foo:/mnt ubuntu sleep infinity")
 	c.Assert(err, IsNil)
 
-	defer s.volcli("volume remove tenant1 foo")
-	defer s.docker("volume rm tenant1/foo")
-	defer s.docker("rm -f " + id)
-
 	out, err := s.volcli("use list")
 	c.Assert(err, IsNil)
 	c.Assert(strings.TrimSpace(out), Equals, "tenant1/foo")
@@ -156,6 +152,15 @@ func (s *systemtestSuite) TestVolCLIUse(c *C) {
 	out, err = s.volcli("use list")
 	c.Assert(err, IsNil)
 	c.Assert(out, Equals, "")
+
+	_, err = s.docker("rm -f " + id)
+	c.Assert(err, IsNil)
+
+	_, err = s.docker("volume rm tenant1/foo")
+	c.Assert(err, IsNil)
+
+	_, err = s.volcli("volume remove tenant1 foo")
+	c.Assert(err, IsNil)
 
 	// the defer comes ahead of time here because of concerns that volume create
 	// will half-create a volume


### PR DESCRIPTION
These tests push the tests for `config` into the 80+ percentile for coverage. The outliers are marshal calls (hard to test and somewhat pointless) and some output validation routines that were particularly hard to trigger due to how things are done in volplugin.

Note that the tests will not pass right now; when @mapuri's ansible etcd changes can be integrated it will pass.