### PR TITLE
Upgrade vagrantssh

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -25,7 +25,7 @@
 		},
 		{
 			"ImportPath": "github.com/contiv/vagrantssh",
-			"Rev": "a88fef02ddd47f0d83326cfdbee8564cade8d143"
+			"Rev": "2b44706f52b6a04d0441e6f0938e13a3e1f0bd49"
 		},
 		{
 			"ImportPath": "github.com/coreos/etcd/client",

--- a/Godeps/_workspace/src/github.com/contiv/vagrantssh/Makefile
+++ b/Godeps/_workspace/src/github.com/contiv/vagrantssh/Makefile
@@ -9,13 +9,19 @@ reflex-test: start
 	reflex -r '\.go' make test
 
 test: deps start golint
-	godep go test -v ./... -check.v
+	godep go test -v -tags vagrant ./... -check.v
+	vagrant ssh host0 -c \
+		"export GOPATH=/vagrant/:/vagrant/Godeps/_workspace; \
+		 if [ \"${http_proxy}\" != \"\" ]; then export http_proxy=${http_proxy}; fi; \
+		 if [ \"${https_proxy}\" != \"\" ]; then export https_proxy=${https_proxy}; fi; \
+		 cd /vagrant/; \
+		 go test -v -tags baremetal ./... -check.v"
 
 golint: deps
-	golint ./...
+	test -z "$$(golint ./... | tee /dev/stderr)"
 
 stop:
 	vagrant destroy -f
 
 start:
-	vagrant up
+	vagrant up --provider virtualbox

--- a/Godeps/_workspace/src/github.com/contiv/vagrantssh/Vagrantfile
+++ b/Godeps/_workspace/src/github.com/contiv/vagrantssh/Vagrantfile
@@ -1,7 +1,12 @@
 Vagrant.configure(2) do |config|
-  config.vm.box = "box-cutter/ubuntu1510"
+  config.vm.box = "contiv/centos71-netplugin"
   (0..2).each do |x|
     config.vm.define "host#{x}" do |host|
+    config.vm.box_version = "0.5.1"
+    # use a private key from within the repo for demo environment. This is used for
+    # baremetal test
+    config.ssh.insert_key = false
+    config.ssh.private_key_path = "./testdata/insecure_private_key"
     end
   end
 end

--- a/Godeps/_workspace/src/github.com/contiv/vagrantssh/baremetal.go
+++ b/Godeps/_workspace/src/github.com/contiv/vagrantssh/baremetal.go
@@ -1,0 +1,112 @@
+/***
+Copyright 2014 Cisco Systems Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vagrantssh
+
+import (
+	"fmt"
+
+	log "github.com/Sirupsen/logrus"
+)
+
+func unexpectedSetupArgError(exptdTypes string, rcvdArgs ...interface{}) error {
+	rcvdTypes := ""
+	for _, arg := range rcvdArgs {
+		rcvdTypes = fmt.Sprintf("%s, %T", rcvdTypes, arg)
+	}
+	return fmt.Errorf("Unexpected args to Setup(). Expected: %s, Received: %s", rcvdTypes, exptdTypes)
+}
+
+// HostInfo contains host specific connectivity info for setting up testbed node
+type HostInfo struct {
+	Name        string
+	SSHAddr     string
+	SSHPort     string
+	User        string
+	PrivKeyFile string
+}
+
+// Baremetal implements a host based testbed
+type Baremetal struct {
+	nodes map[string]TestbedNode
+}
+
+// setup implement baremetal testbed specific initilization. It takes a list of
+// connectivity infos about the hosts and initilizes ssh client state used by tests.
+func (b *Baremetal) setup(hosts []HostInfo) error {
+	b.nodes = make(map[string]TestbedNode)
+
+	for _, h := range hosts {
+		log.Infof("Adding node: %q(%s:%s:%s:%s)", h.Name, h.SSHAddr, h.SSHPort, h.User, h.PrivKeyFile)
+		var (
+			node *SSHNode
+			err  error
+		)
+		if node, err = NewSSHNode(h.Name, h.User, h.SSHAddr, h.SSHPort, h.PrivKeyFile); err != nil {
+			return err
+		}
+		b.nodes[node.GetName()] = TestbedNode(node)
+	}
+
+	return nil
+}
+
+// Setup initializes a baremetal testbed.
+func (b *Baremetal) Setup(args ...interface{}) error {
+	if _, ok := args[0].([]HostInfo); !ok {
+		return unexpectedSetupArgError("[]vagrantssh.HostInfo", args...)
+	}
+	return b.setup(args[0].([]HostInfo))
+}
+
+// Teardown cleans up a baremetal testbed.
+func (b *Baremetal) Teardown() {
+	for _, node := range b.nodes {
+		vnode, ok := node.(*SSHNode)
+		if !ok {
+			log.Errorf("invalid node type encountered: %T", vnode)
+			continue
+		}
+		vnode.Cleanup()
+	}
+	b.nodes = nil
+}
+
+// GetNode obtains a node by name. The name is the name of the host provided at
+// the time of testbed Setup.
+func (b *Baremetal) GetNode(name string) TestbedNode {
+	return b.nodes[name]
+}
+
+// GetNodes returns the nodes in a baremetal setup, returned sequentially.
+func (b *Baremetal) GetNodes() []TestbedNode {
+	var ret []TestbedNode
+	for _, value := range b.nodes {
+		ret = append(ret, value)
+	}
+
+	return ret
+}
+
+// IterateNodes walks each host and executes the function supplied. On error,
+// it waits for all hosts to complete before returning the error, if any.
+func (b *Baremetal) IterateNodes(fn func(TestbedNode) error) error {
+	return iterateNodes(b, fn)
+}
+
+// SSHExecAllNodes will ssh into each host and run the specified command.
+func (b *Baremetal) SSHExecAllNodes(cmd string) error {
+	return sshExecAllNodes(b, cmd)
+}

--- a/Godeps/_workspace/src/github.com/contiv/vagrantssh/testbed.go
+++ b/Godeps/_workspace/src/github.com/contiv/vagrantssh/testbed.go
@@ -15,11 +15,48 @@ limitations under the License.
 
 package vagrantssh
 
+import (
+	"fmt"
+	"sync"
+)
+
 // Testbed is a collection of test nodes
 type Testbed interface {
-	Setup(start bool, env string, numNodes int) error
+	Setup(args ...interface{}) error
 	Teardown()
 	GetNodes() []TestbedNode
 	GetNode(name string) TestbedNode
 	IterateNodes(fn func(TestbedNode) error) error
+}
+
+func iterateNodes(tb Testbed, fn func(TestbedNode) error) error {
+	wg := sync.WaitGroup{}
+	nodes := tb.GetNodes()
+	errChan := make(chan error, len(nodes))
+
+	for _, node := range nodes {
+		wg.Add(1)
+
+		go func(node TestbedNode) {
+			if err := fn(node); err != nil {
+				errChan <- fmt.Errorf(`Error: "%v" on host: %q"`, err, node.GetName())
+			}
+			wg.Done()
+		}(node)
+	}
+
+	wg.Wait()
+
+	select {
+	case err := <-errChan:
+		return err
+	default:
+		return nil
+	}
+}
+
+func sshExecAllNodes(tb Testbed, cmd string) error {
+	return tb.IterateNodes(func(node TestbedNode) error {
+		return node.RunCommand(cmd)
+	})
 }

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -108,7 +108,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       end
 
       # Run the provisioner after the last machine comes up
-      config.vm.provision 'ansible', &ansible_provision if i == (NMONS - 1)
+      mon.vm.provision 'ansible', &ansible_provision if i == (NMONS - 1)
     end
   end
 end


### PR DESCRIPTION
This upgrades github.com/contiv/vagrantssh to vendor in the new 1.8 fixes. It also brings in a critical `Vagrantfile` change for 1.8.