### PR TITLE
Godep fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ cover.out
 bin/*
 ansible/docker
 *.vdi
+.bundle
 .vagrant
 ansible/fetch/*
 volmaster/volmaster

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ test: godep unit-test system-test
 unit-test:
 	vagrant ssh mon0 -c 'sudo -i sh -c "cd $(GUESTGOPATH); make unit-test-host"'
 
-unit-test-host: golint-host govet-host
+unit-test-host: godep golint-host govet-host
 	godep go list ./... | HOST_TEST=1 GOGC=1000 xargs -I{} godep go test -v '{}' -coverprofile=$(GUESTPREFIX)/src/{}/cover.out -check.v
 
 unit-test-nocoverage:


### PR DESCRIPTION
This fixes a small issue with godeps not being installed on VMs that were in a state where no build happened before the tests were run.

It also removes the `.bundle` directory (which is typically caused by a Gemfile) that vagrant 1.8 creates now.

Since this is so insignificant, I'm going to merge this once tests pass.