### PR TITLE
minor corrections in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,10 @@ Your guests will configure themselves.
 
 Be sure to start and run the environment with `make start` before you
 continue with these steps. You must have working vagrant, virtualbox, and
-ansible.
+ansible. If you are behind a proxy server, then use only http proxy.
 
 These instructions ssh you into the `mon0` vm. If you wish to test the
-cross-host functionality, ssh into `mon1` or `mon2` with `vagrant ssh`. Then
-start at the "starting volplugin" (not volmaster) step.
+cross-host functionality, ssh into `mon1` or `mon2` with `vagrant ssh`.
 
 1. Run the suite: `make run`.
 1. SSH into the host: `make ssh`.

--- a/README.md
+++ b/README.md
@@ -55,8 +55,10 @@ Your guests will configure themselves.
 
 Be sure to start and run the environment with `make start` before you
 continue with these steps. You must have working vagrant, virtualbox, and
-ansible. If you are behind a proxy server, set the https_proxy same as the
-http_proxy. This is because of a current limitation with ansible.
+ansible. If you are behind a proxy server, set the `https_proxy` same as the
+`http_proxy`. Ansible has a current limitation (https://github.com/ansible/ansible/issues/10941), 
+that it only supports `http://` proxy. So, `https_proxy` should be set to
+`"http://<proxyserver>:<port>"`
 
 These instructions ssh you into the `mon0` vm. If you wish to test the
 cross-host functionality, ssh into `mon1` or `mon2` with `vagrant ssh`.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ Your guests will configure themselves.
 
 Be sure to start and run the environment with `make start` before you
 continue with these steps. You must have working vagrant, virtualbox, and
-ansible. If you are behind a proxy server, then use only http proxy.
+ansible. If you are behind a proxy server, set the https_proxy same as the
+http_proxy. This is because of a current limitation with ansible.
 
 These instructions ssh you into the `mon0` vm. If you wish to test the
 cross-host functionality, ssh into `mon1` or `mon2` with `vagrant ssh`.


### PR DESCRIPTION
`make run` will run both the volplugin and volmaster on all the hosts. so, the statement about "starting volplugin" manually is not necessary.
make start will fail if https_proxy is specified. so, adding a note for not using https_proxy as ansible does not support.