### PR TITLE
Unified exec pipeline

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -1,0 +1,238 @@
+// Package executor implements a high level execution context with monitoring and
+// logging features.
+//
+// Please see Executor for more information.
+package executor
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os/exec"
+	"syscall"
+	"time"
+
+	"github.com/Sirupsen/logrus"
+)
+
+// ExecResult is the result of a Wait() operation and contains various fields
+// related to the post-mortem state of the process such as output and exit
+// status.
+type ExecResult struct {
+	Stdout     string
+	Stderr     string
+	ExitStatus uint32
+	Runtime    time.Duration
+
+	executor *Executor
+}
+
+// Executor is the context used to execute a process. The runtime state is kept
+// here. Please see the struct fields for more information.
+//
+// New() is the appropriate way to initialize this type.
+//
+// No attempt is made to manage concurrent requests to this struct after
+// the program has started.
+type Executor struct {
+	// The interval at which we will log that we are still running.
+	LogInterval time.Duration
+
+	// If a true value is passed into this channel, the process will be forcefully
+	// terminated. A false value terminates only the supervising goroutines, and
+	// is used by Wait().
+	TerminateChan chan bool
+
+	// The function used for logging. Expects a format-style string and trailing args.
+	LogFunc func(string, ...interface{})
+
+	// The stdin as passed to the process.
+	Stdin io.Reader
+
+	timeout time.Duration
+
+	command         *exec.Cmd
+	stdout          io.ReadCloser
+	stderr          io.ReadCloser
+	startTime       time.Time
+	terminateLogger chan struct{}
+}
+
+// New creates a new executor from an *exec.Cmd. You may modify the values
+// before calling Start(). See Executor for more information.
+func New(cmd *exec.Cmd) *Executor {
+	return &Executor{
+		LogInterval:   1 * time.Minute,
+		TerminateChan: make(chan bool, 1),
+		LogFunc:       logrus.Debugf,
+		command:       cmd,
+		stdout:        nil,
+		stderr:        nil,
+	}
+}
+
+func (e *Executor) String() string {
+	return fmt.Sprintf("%v (%v) (pid: %v)", e.command.Args, e.command.Path, e.PID())
+}
+
+// SetTimeout sets the process timeout. If a non-zero timeout is provided, it
+// will forcefully terminate the process after it is reached. It must be called
+// before Start().
+func (e *Executor) SetTimeout(t time.Duration) {
+	e.timeout = t
+}
+
+// Start starts the command in the Executor context. It returns any error upon
+// starting the process, but does not wait for it to complete. You may control
+// it in a variety of ways (see Executor for more information).
+func (e *Executor) Start() error {
+	e.command.Stdin = e.Stdin
+
+	e.startTime = time.Now()
+	e.terminateLogger = make(chan struct{}, 1)
+
+	var err error
+
+	e.stdout, err = e.command.StdoutPipe()
+	if err != nil {
+		return err
+	}
+
+	e.stderr, err = e.command.StderrPipe()
+	if err != nil {
+		return err
+	}
+
+	if err := e.command.Start(); err != nil {
+		e.LogFunc("Error executing %v: %v", e, err)
+		return err
+	}
+
+	go e.waitForStop()
+
+	if e.timeout != 0 {
+		go e.terminateTimeout()
+	}
+
+	go e.logInterval()
+
+	return nil
+}
+
+// TimeRunning returns the amount of time the program is or was running. Also
+// see ExecResult.Runtime.
+func (e *Executor) TimeRunning() time.Duration {
+	return time.Now().Sub(e.startTime)
+}
+
+func (e *Executor) terminateTimeout() {
+	time.Sleep(e.timeout)
+	e.TerminateChan <- true
+}
+
+func (e *Executor) waitForStop() {
+	terminate := <-e.TerminateChan
+
+	if terminate {
+		if e.command.Process == nil {
+			e.LogFunc("Could not terminate non-running command %v", e)
+		} else {
+			e.LogFunc("Command %v terminated due to timeout. It may not have finished!", e)
+			e.command.Process.Kill()
+		}
+	}
+
+	e.terminateLogger <- struct{}{}
+	return
+}
+
+func (e *Executor) logInterval() {
+	for {
+		time.Sleep(e.LogInterval)
+		select {
+		case <-e.terminateLogger:
+			return
+		default:
+			e.LogFunc("%v has been running for %v", e, e.TimeRunning())
+		}
+	}
+}
+
+// PID yields the pid of the process (dead or alive), or 0 if the process has
+// not been run yet.
+func (e *Executor) PID() uint32 {
+	if e.command.Process != nil {
+		return uint32(e.command.Process.Pid)
+	}
+
+	return 0
+}
+
+// Wait waits for the process and return an ExecResult. The program died due to
+// another problem without returning an exit status, a nil result is yielded.B
+//
+// If the ExecResult is returned, error will be nil, regardless of the
+// ExitError returned by (*exec.Cmd).Wait(). If an error is returned it should
+// be handled appropriately.
+func (e *Executor) Wait() (*ExecResult, error) {
+	stdout, err := ioutil.ReadAll(e.stdout)
+	if err != nil {
+		return nil, err
+	}
+
+	stderr, err := ioutil.ReadAll(e.stderr)
+	if err != nil {
+		return nil, err
+	}
+
+	res := &ExecResult{
+		executor: e,
+		Stdout:   string(stdout),
+		Stderr:   string(stderr),
+	}
+
+	err = e.command.Wait()
+
+	e.TerminateChan <- false // signal goroutines to terminate gracefully
+
+	if err != nil {
+		// if not exiterror, do not yield an execresult
+		if exit, ok := err.(*exec.ExitError); ok {
+			res.ExitStatus = uint32(exit.Sys().(syscall.WaitStatus))
+		} else {
+			return nil, err
+		}
+	}
+
+	res.Runtime = e.TimeRunning()
+	return res, nil
+}
+
+// Run calls Start(), then Wait(), and returns an ExecResult and error (if
+// any). If an error is returned, ExecResult will be nil.
+func (e *Executor) Run() (*ExecResult, error) {
+	if err := e.Start(); err != nil {
+		return nil, err
+	}
+
+	er, err := e.Wait()
+	if err != nil {
+		return nil, err
+	}
+
+	return er, nil
+}
+
+// Out returns an *os.File which is the stream of the standard output stream.
+func (e *Executor) Out() io.ReadCloser {
+	return e.stdout
+}
+
+// Err returns an io.ReadCloser which is the stream of the standard error stream.
+func (e *Executor) Err() io.ReadCloser {
+	return e.stderr
+}
+
+func (er *ExecResult) String() string {
+	return fmt.Sprintf("Command: %v, Exit status %v, Runtime %v", er.executor.command.Path, er.ExitStatus, er.Runtime)
+}

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -1,0 +1,155 @@
+package executor
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os/exec"
+	"syscall"
+	. "testing"
+	"time"
+
+	. "gopkg.in/check.v1"
+)
+
+type execSuite struct{}
+
+var cmd = []string{"/bin/sleep", "200000000"}
+
+var _ = Suite(&execSuite{})
+
+func TestExec(t *T) {
+	TestingT(t)
+}
+
+func (es *execSuite) TestProperties(c *C) {
+	mycmd := exec.Command(cmd[0], cmd[1:]...)
+	e := New(mycmd)
+	c.Assert(e, NotNil)
+	c.Assert(mycmd, DeepEquals, e.command)
+	c.Assert(e.LogInterval, Equals, 1*time.Minute)
+	c.Assert(e.TerminateChan, NotNil)
+	c.Assert(e.Stdin, IsNil)
+	c.Assert(e.timeout, Equals, time.Duration(0))
+}
+
+func (es *execSuite) TestStartWait(c *C) {
+	e := New(exec.Command(cmd[0], cmd[1:]...))
+	c.Assert(e, NotNil)
+	c.Assert(e.Start(), IsNil)
+	c.Assert(e.PID(), Not(Equals), uint32(0))
+	c.Assert(e.command.Process, NotNil)
+	// the sleep requires we signal the process since it'll sleepp forever.
+	c.Assert(e.command.Process.Signal(syscall.SIGTERM), IsNil)
+	er, err := e.Wait()
+	c.Assert(err, IsNil)
+	c.Assert(er, NotNil)
+	c.Assert(er.ExitStatus, Equals, uint32(15))
+	c.Assert(er.Runtime, Not(Equals), time.Duration(0))
+}
+
+func (es *execSuite) TestStdio(c *C) {
+	cmd := exec.Command("/bin/echo", "yes")
+	e := New(cmd)
+	c.Assert(e.Start(), IsNil)
+	time.Sleep(100 * time.Millisecond) // let it run a bit
+	// yes runs eternally, so kill it manually.
+	c.Assert(e.command.Process.Signal(syscall.SIGTERM), IsNil)
+	er, _ := e.Wait()
+	c.Assert(er, NotNil)
+	c.Assert(er.Stdout, Matches, "yes\n")
+	cmd = exec.Command("sh", "-c", "echo yes 1>&2")
+	e = New(cmd)
+	c.Assert(e.Start(), IsNil)
+	time.Sleep(100 * time.Millisecond) // let it run a bit
+	// yes runs eternally, so kill it manually.
+	c.Assert(e.command.Process.Signal(syscall.SIGTERM), IsNil)
+	er, _ = e.Wait()
+	c.Assert(er, NotNil)
+	c.Assert(er.Stderr, Matches, "yes\n")
+
+	cmd = exec.Command("/bin/echo", "yes")
+	e = New(cmd)
+	c.Assert(e.Start(), IsNil)
+
+	buf := new(bytes.Buffer)
+	io.Copy(buf, e.Out())
+	c.Assert(buf.String(), Equals, "yes\n")
+
+	cmd = exec.Command("sh", "-c", "echo yes 1>&2")
+	e = New(cmd)
+	c.Assert(e.Start(), IsNil)
+
+	buf = new(bytes.Buffer)
+	io.Copy(buf, e.Err())
+	c.Assert(buf.String(), Equals, "yes\n")
+
+	cmd = exec.Command("cat")
+	e = New(cmd)
+	e.Stdin = bytes.NewBufferString("foo")
+	c.Assert(e.Start(), IsNil)
+	er, err := e.Wait()
+	c.Assert(err, IsNil)
+	c.Assert(er.Stdout, Equals, "foo")
+}
+
+func (es *execSuite) TestTimeout(c *C) {
+	e := New(exec.Command(cmd[0], cmd[1:]...))
+	results := []string{}
+	loggerFunc := func(s string, args ...interface{}) {
+		results = append(results, s)
+	}
+
+	e.LogFunc = loggerFunc
+	e.SetTimeout(1 * time.Second)
+	c.Assert(e.Start(), IsNil)
+	time.Sleep(2 * time.Second)
+	c.Assert(results[0], Equals, "Command %v terminated due to timeout. It may not have finished!")
+	er, err := e.Wait()
+	c.Assert(err, IsNil)
+	c.Assert(er.ExitStatus, Not(Equals), 0)
+
+	e = New(exec.Command("/bin/sleep", "2"))
+	results = []string{}
+	e.LogFunc = loggerFunc
+	e.SetTimeout(4 * time.Second)
+	er, err = e.Run()
+	c.Assert(err, IsNil)
+	c.Assert(er.ExitStatus, Equals, uint32(0))
+	time.Sleep(2 * time.Second)
+	c.Assert(len(results), Equals, 0)
+}
+
+func (es *execSuite) TestLogger(c *C) {
+	results := []string{}
+	loggerFunc := func(s string, args ...interface{}) {
+		results = append(results, s)
+	}
+
+	cmd := exec.Command("/bin/sleep", "2")
+
+	e := New(cmd)
+	e.LogFunc = loggerFunc
+	e.LogInterval = 1 * time.Second
+	c.Assert(e.Start(), IsNil)
+	time.Sleep(2 * time.Second)
+	er, _ := e.Wait()
+	c.Assert(er.ExitStatus, Equals, uint32(0))
+	c.Assert(er.Runtime > 2*time.Second, Equals, true)
+	// sometimes (depending on how long it takes to `cmd.Start()` launch) the
+	// logger will log twice and other times it will only log once. To keep the
+	// tests reliable, we only test the first log.
+	c.Assert(results[0], Equals, "%v has been running for %v")
+}
+
+func (es *execSuite) TestString(c *C) {
+	e := New(exec.Command(cmd[0], cmd[1:]...))
+	c.Assert(e.String(), Equals, "[/bin/sleep 200000000] (/bin/sleep) (pid: 0)")
+	c.Assert(e.Start(), IsNil)
+	c.Assert(e.PID(), Not(Equals), uint32(0))
+	c.Assert(e.String(), Equals, fmt.Sprintf("[/bin/sleep 200000000] (/bin/sleep) (pid: %v)", e.PID()))
+	c.Assert(e.command.Process.Signal(syscall.SIGTERM), IsNil)
+	er, _ := e.Wait()
+	c.Assert(er, NotNil)
+	c.Assert(er.ExitStatus, Equals, uint32(15))
+}

--- a/storage/backend/ceph/internals.go
+++ b/storage/backend/ceph/internals.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/contiv/volplugin/executor"
 	"github.com/contiv/volplugin/storage"
 
 	log "github.com/Sirupsen/logrus"
@@ -15,9 +16,13 @@ import (
 func (c *Driver) lockImage(do storage.DriverOptions) error {
 	poolName := do.Volume.Params["pool"]
 
-	if err := exec.Command("rbd", "lock", "add", do.Volume.Name, do.Volume.Name, "--pool", poolName).Run(); err != nil {
-		log.Debugf("Could not acquire lock for %q: %v", do.Volume.Name, err)
-		return err
+	er, err := executor.New(exec.Command("rbd", "lock", "add", do.Volume.Name, do.Volume.Name, "--pool", poolName)).Run()
+	if err != nil {
+		return fmt.Errorf("Could not acquire lock for %q: %v", do.Volume.Name, err)
+	}
+
+	if er.ExitStatus != 0 {
+		return fmt.Errorf("Could not acquire lock for %q: %v", do.Volume.Name, err)
 	}
 
 	return nil
@@ -26,20 +31,29 @@ func (c *Driver) lockImage(do storage.DriverOptions) error {
 func (c *Driver) unlockImage(do storage.DriverOptions) error {
 	poolName := do.Volume.Params["pool"]
 
-	output, err := exec.Command("rbd", "lock", "--format", "json", "list", do.Volume.Name, "--pool", poolName).Output()
+	er, err := executor.New(exec.Command("rbd", "lock", "--format", "json", "list", do.Volume.Name, "--pool", poolName)).Run()
 	if err != nil {
 		return fmt.Errorf("Error running `rbd lock list` for volume %q: %v", do.Volume.Name, err)
 	}
 
+	if er.ExitStatus != 0 {
+		return fmt.Errorf("Error running `rbd lock list` for volume %q: %v", do.Volume.Name, er)
+	}
+
 	locks := map[string]map[string]string{}
 
-	if err := json.Unmarshal(output, &locks); err != nil {
+	if err := json.Unmarshal([]byte(er.Stdout), &locks); err != nil {
 		return fmt.Errorf("Error unmarshalling lock report for volume %q: %v", do.Volume.Name, err)
 	}
 
 	if _, ok := locks[do.Volume.Name]; ok {
-		if err := exec.Command("rbd", "lock", "remove", do.Volume.Name, do.Volume.Name, locks[do.Volume.Name]["locker"], "--pool", poolName).Run(); err != nil {
+		er, err := executor.New(exec.Command("rbd", "lock", "remove", do.Volume.Name, do.Volume.Name, locks[do.Volume.Name]["locker"], "--pool", poolName)).Run()
+		if err != nil {
 			return fmt.Errorf("Error releasing lock on volume %q: %v", do.Volume.Name, err)
+		}
+
+		if er.ExitStatus != 0 {
+			return fmt.Errorf("Error releasing lock on volume %q: %v", do.Volume.Name, er)
 		}
 	}
 
@@ -63,24 +77,28 @@ func (c *Driver) mapImage(do storage.DriverOptions) (string, error) {
 		return "", err
 	}
 
-	blkdev, err := exec.Command("rbd", "map", do.Volume.Name, "--pool", poolName).Output()
-	device := strings.TrimSpace(string(blkdev))
-
+	er, err := executor.New(exec.Command("rbd", "map", do.Volume.Name, "--pool", poolName)).Run()
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("Could not map %q: %v", do.Volume.Name, err)
+	}
+	if er.ExitStatus != 0 {
+		return "", fmt.Errorf("Could not map %q: %v", do.Volume.Name, er)
 	}
 
-	if device == "" {
-		output, err := exec.Command("rbd", "showmapped", "--format", "json").Output()
+	device := strings.TrimSpace(er.Stdout)
 
+	if device == "" {
+		er, err := executor.New(exec.Command("rbd", "showmapped", "--format", "json")).Run()
 		if err != nil {
-			return "", err
+			return "", fmt.Errorf("Could not show mapped volumes: %v", err)
 		}
 
-		err = json.Unmarshal(output, &rbdMaps)
+		if er.ExitStatus != 0 {
+			return "", fmt.Errorf("Could not show mapped volumes: %v", er)
+		}
 
-		if err != nil {
-			return "", fmt.Errorf("Could not parse RBD showmapped output: %s", output)
+		if err := json.Unmarshal([]byte(er.Stdout), &rbdMaps); err != nil {
+			return "", fmt.Errorf("Could not parse RBD showmapped output: %s", er.Stdout)
 		}
 
 		for i := range rbdMaps {
@@ -102,22 +120,30 @@ func (c *Driver) mapImage(do storage.DriverOptions) (string, error) {
 
 func (c *Driver) mkfsVolume(fscmd, devicePath string) error {
 	// Create ext4 filesystem on the device. this will take a while
-	if _, err := exec.Command("/bin/sh", "-c", templateFSCmd(fscmd, devicePath)).CombinedOutput(); err != nil {
+	er, err := executor.New(exec.Command("/bin/sh", "-c", templateFSCmd(fscmd, devicePath))).Run()
+	if err != nil {
 		return fmt.Errorf("Error creating filesystem on %s with cmd: %q. Error: %v", devicePath, fscmd, err)
+	}
+	if er.ExitStatus != 0 {
+		return fmt.Errorf("Error creating filesystem on %s with cmd: %q. Error: %v", devicePath, fscmd, er)
 	}
 
 	return nil
 }
 
 func (c *Driver) unmapImage(do storage.DriverOptions) error {
+	// FIXME use mapImage showmapped json code
 	poolName := do.Volume.Params["pool"]
 
-	output, err := exec.Command("rbd", "showmapped", "--pool", poolName).Output()
+	er, err := executor.New(exec.Command("rbd", "showmapped", "--pool", poolName)).Run()
 	if err != nil {
-		return err
+		return fmt.Errorf("Could not show mapped rbd volumes for pool %q: %v", poolName, err)
+	}
+	if er.ExitStatus != 0 {
+		return fmt.Errorf("Could not show mapped rbd volumes for pool %q: %v", poolName, er)
 	}
 
-	lines := strings.Split(string(output), "\n")
+	lines := strings.Split(er.Stdout, "\n")
 	if len(lines) < 2 {
 		return nil // no mapped images
 	}
@@ -131,8 +157,12 @@ func (c *Driver) unmapImage(do storage.DriverOptions) error {
 
 		if strings.TrimSpace(pool) == poolName && strings.TrimSpace(image) == do.Volume.Name {
 			log.Debugf("Unmapping volume %s/%s at device %q", poolName, do.Volume.Name, strings.TrimSpace(device))
-			if err := exec.Command("rbd", "unmap", device).Run(); err != nil {
-				return err
+			er, err := executor.New(exec.Command("rbd", "unmap", device)).Run()
+			if err != nil {
+				return fmt.Errorf("Could not unmap volume %q (device %q): %v", do.Volume.Name, device, err)
+			}
+			if er.ExitStatus != 0 {
+				return fmt.Errorf("Could not unmap volume %q (device %q): %v", do.Volume.Name, device, er)
 			}
 		}
 	}

--- a/storage/backend/ceph/mountscan.go
+++ b/storage/backend/ceph/mountscan.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/contiv/volplugin/executor"
 	"github.com/contiv/volplugin/storage"
 )
 
@@ -100,13 +101,17 @@ func getMounts() ([]*storage.Mount, error) {
 }
 
 func getMapped() ([]*storage.Mount, error) {
-	out, err := exec.Command("rbd", "showmapped").Output()
+	// FIXME unify all these showmapped commands
+	er, err := executor.New(exec.Command("rbd", "showmapped")).Run()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("Could not show mapped volumes: %v", err)
+	}
+	if er.ExitStatus != 0 {
+		return nil, fmt.Errorf("Could not show mapped volumes: %v", er)
 	}
 
 	mounts := []*storage.Mount{}
-	for i, line := range strings.Split(string(out), "\n") {
+	for i, line := range strings.Split(er.Stdout, "\n") {
 		if i == 0 {
 			continue
 		}

--- a/storage/backend/ceph/util.go
+++ b/storage/backend/ceph/util.go
@@ -5,16 +5,21 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/contiv/volplugin/executor"
 )
 
 func (c *Driver) poolExists(poolName string) (bool, error) {
-	cmd := exec.Command("ceph", "osd", "pool", "ls")
-	out, err := cmd.Output()
+	er, err := executor.New(exec.Command("ceph", "osd", "pool", "ls")).Run()
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("Problem listing pools: %v", err)
 	}
 
-	lines := strings.Split(string(out), "\n")
+	if er.ExitStatus != 0 {
+		return false, fmt.Errorf("Problem listing pools: %v", er)
+	}
+
+	lines := strings.Split(er.Stdout, "\n")
 	for _, line := range lines {
 		line = strings.TrimSpace(line)
 		if line == poolName {


### PR DESCRIPTION
This principally affects the ceph driver but it implements (see first commit) a new package called `executor` which is a supervising and interruptible... a wrapper for exec.Cmd structs.

The second commit is the integration into the ceph driver. It does not do anything with hard timeouts yet, but we have a few other steps that need to be taken before we can start leveraging that feature.