### PR TITLE
Dockerfile,.dockerignore,Makefile: docker image support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+.vagrant
+.bundle

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM ceph/rbd
+
+ADD bin/volmaster /bin/volmaster
+ADD bin/volplugin /bin/volplugin
+ADD bin/volcli /bin/volcli
+ADD bin/volsupervisor /bin/volsupervisor
+
+ENTRYPOINT []

--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,12 @@ build: golint govet
 	vagrant ssh mon0 -c 'sudo -i sh -c "cd $(GUESTGOPATH); make run-build"'
 	make run
 
+docker: run-build
+	docker build -t contiv/volplugin .
+
+docker-push: docker
+	docker push contiv/volplugin
+
 run:
 	@set -e; for i in $$(seq 0 2); do vagrant ssh mon$$i -c 'cd $(GUESTGOPATH) && make run-volplugin run-volmaster'; done
 	vagrant ssh mon0 -c 'cd $(GUESTGOPATH) && make run-volsupervisor'


### PR DESCRIPTION
This allows docker images to be built and pushed to the hub.