### PR TITLE
Bash autocomplete for volcli

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ TAR_FILE := $(TAR_LOC)/$(TAR_FILENAME)
 
 tar: clean-tar run-build
 	@echo "v0.0.0-`date -u +%m-%d-%Y.%H-%M-%S.UTC`" > $(VERSION_FILE)
-	@tar -jcf $(TAR_FILE) -C $(GOPATH)/bin volcli volmaster volplugin volsupervisor
+	@tar -jcf $(TAR_FILE) -C $(GOPATH)/bin volcli volmaster volplugin volsupervisor -C $(GOPATH)/src/github.com/contiv/volplugin contrib/completion/bash/volcli
 
 clean-tar:
 	@rm -f $(TAR_LOC)/*.$(TAR_EXT)

--- a/contrib/completion/bash/volcli
+++ b/contrib/completion/bash/volcli
@@ -71,8 +71,10 @@ _volcli() {
                 list)
                     ;;
                 get)
+					_volcli_complete_tenant_volume_pair
                     ;;
                 force-remove)
+					_volcli_complete_tenant_volume_pair
                     ;;
                 *)
                     COMPREPLY=( $( compgen -W "get list force-remove help" -- "$cur" ) )

--- a/contrib/completion/bash/volcli
+++ b/contrib/completion/bash/volcli
@@ -1,0 +1,126 @@
+#! /bin/bash
+
+GLOBAL_COMMANDS="\
+    tenant\
+    volume\
+    use\
+    help"
+
+GLOBAL_OPTIONS="\
+    --prefix\
+    --etcd\
+    --version\
+    --help"
+
+# Fetch all tenant names
+_volcli_complete_tenants() {
+	COMPREPLY=( $(compgen -W '$(volcli tenant list)' -- "$cur") )
+}
+
+_volcli_complete_tenant_volume_pair() {
+	COMPREPLY=( $(compgen -W '$(volcli volume list-all)' -- "$cur") )
+}
+
+
+_volcli() {
+    local cur prev firstword secondword complete_words complete_options
+
+    cur=${COMP_WORDS[COMP_CWORD]}
+    prev=${COMP_WORDS[COMP_CWORD-1]}
+    firstword=$(_volcli_get_firstword)
+    secondword=$(_volcli_get_secondword)
+
+    #echo -e "\nprev = $prev, cur = $cur, firstword = $firstword, secondword = $secondword \n"
+    case "${firstword}" in
+        tenant)
+            case "${secondword}" in
+                get)
+            		_volcli_complete_tenants
+					return
+                    ;;
+                delete)
+            		_volcli_complete_tenants
+                    ;;
+                upload|list)
+                    ;;
+                *)
+                    COMPREPLY=( $( compgen -W "upload get list delete help" -- "$cur" ) )
+                    ;;
+            esac
+            ;;
+        volume)
+            case "${secondword}" in
+                create)
+            		_volcli_complete_tenants
+                    ;;
+                list)
+            		_volcli_complete_tenants
+                    ;;
+                list-all)
+                    ;;
+                remove|force-remove)
+					_volcli_complete_tenant_volume_pair
+                    ;;
+                *)
+                    COMPREPLY=( $( compgen -W "create remove force-remove list list-all help" -- "$cur" ) )
+                    ;;
+            esac
+            ;;
+        use)
+            case "${secondword}" in
+                list)
+                    ;;
+                get)
+                    ;;
+                force-remove)
+                    ;;
+                *)
+                    COMPREPLY=( $( compgen -W "get list force-remove help" -- "$cur" ) )
+                    ;;
+            esac
+            ;;
+
+        *)
+            if [[ $cur == -* ]]; then
+                COMPREPLY=( $( compgen -W "$GLOBAL_OPTIONS" -- "$cur" ) )
+            else
+                COMPREPLY=( $( compgen -W "$GLOBAL_COMMANDS" -- "$cur" ) )
+            fi
+            ;;
+    esac
+}
+
+
+# Get the first word that is not an option flag.
+# Usually the command
+_volcli_get_firstword() {
+    local firstword i
+
+    firstword=
+    for ((i = 1; i < ${#COMP_WORDS[@]}; ++i)); do
+        if [[ ${COMP_WORDS[i]} != -* ]]; then
+            firstword=${COMP_WORDS[i]}
+            break
+        fi
+    done
+
+    echo $firstword
+}
+
+# Get the second word that is not an option flag.
+# Usually the sub-command
+_volcli_get_secondword() {
+    local secondword i
+
+    secondword=
+    for ((i = 2; i < ${#COMP_WORDS[@]}; ++i)); do
+        if [[ ${COMP_WORDS[i]} != -* ]]; then
+            secondword=${COMP_WORDS[i]}
+            break
+        fi
+    done
+
+    echo $secondword
+}
+
+complete -F _volcli volcli


### PR DESCRIPTION
(1) Bash autocompletion file for volcli
(2) change to package this file in the tar

note: the ansible changes for copying the volcli file to /etc/bash_completion.d/ need to be done. They  will be done after the Makefile change is merged, as a tar with the changes is required to deploy.

for now, to test these changes one needs to,
sudo cp contrib/completion/bash/volcli /etc/bash_completion.d/
source /etc/bash_completion.d/volcli

```
[vagrant@mon0 volplugin]$ volcli
help    tenant  use     volume
[vagrant@mon0 volplugin]$ volcli tenant
delete  get     help    list    upload
[vagrant@mon0 volplugin]$
[vagrant@mon0 volplugin]$ volcli tenant get tenant
tenant1  tenant2
[vagrant@mon0 volplugin]$
[vagrant@mon0 volplugin]$ volcli tenant delete tenant
tenant1  tenant2
[vagrant@mon0 volplugin]$
[vagrant@mon0 volplugin]$ volcli volume
create        force-remove  help          list          list-all      remove
[vagrant@mon0 volplugin]$
[vagrant@mon0 volplugin]$ volcli volume create tenant
tenant1  tenant2
[vagrant@mon0 volplugin]$
[vagrant@mon0 volplugin]$ volcli volume list tenant
tenant1  tenant2
[vagrant@mon0 volplugin]$
[vagrant@mon0 volplugin]$ volcli volume remove tenant
tenant1/volume1  tenant2/volume2
[vagrant@mon0 volplugin]$
[vagrant@mon0 volplugin]$ volcli volume force-remove tenant
tenant1/volume1  tenant2/volume2
[vagrant@mon0 volplugin]$
[vagrant@mon0 volplugin]$ volcli use
force-remove  get           help          list
[vagrant@mon0 volplugin]$
[vagrant@mon0 volplugin]$ volcli use get tenant
tenant1/volume1  tenant2/volume2
[vagrant@mon0 volplugin]$
[vagrant@mon0 volplugin]$ volcli use force-remove tenant
tenant1/volume1  tenant2/volume2
[vagrant@mon0 volplugin]$
```