### PR TITLE
ansible/roles/docker: use overlayfs storage backend.

### DIFF
--- a/ansible/roles/docker/templates/docker-svc.j2
+++ b/ansible/roles/docker/templates/docker-svc.j2
@@ -6,7 +6,7 @@ Requires=docker.socket
 
 [Service]
 Type=notify
-ExecStart=/usr/bin/docker daemon -H fd:// --cluster-store=etcd://localhost:{{ etcd_client_port1 }}
+ExecStart=/usr/bin/docker daemon -s overlay -H fd:// --cluster-store=etcd://localhost:{{ etcd_client_port1 }}
 MountFlags=slave
 LimitNOFILE=1048576
 LimitNPROC=1048576


### PR DESCRIPTION
Merging as soon as tests pass.

This cuts runtime for tests in half.