### PR TITLE
volplugin,systemtests: ensure no FDs are carried by keepalive connections over the unix socket.

### DIFF
--- a/systemtests/volplugin_test.go
+++ b/systemtests/volplugin_test.go
@@ -7,7 +7,14 @@ import (
 	"github.com/contiv/volplugin/config"
 
 	. "gopkg.in/check.v1"
+
+	log "github.com/Sirupsen/logrus"
 )
+
+func (s *systemtestSuite) TestVolpluginFDLeak(c *C) {
+	log.Info("Running 2000 iterations of `docker volume ls` to ensure no FD exhaustion")
+	c.Assert(s.vagrant.GetNode("mon0").RunCommand("set -e; for i in $(seq 0 2000); do docker volume ls; done"), IsNil)
+}
 
 func (s *systemtestSuite) TestVolpluginCrashRestart(c *C) {
 	c.Assert(s.createVolume("mon0", "tenant1", "test", nil), IsNil)

--- a/volplugin/volplugin.go
+++ b/volplugin/volplugin.go
@@ -71,7 +71,9 @@ func (dc *DaemonConfig) Daemon() error {
 		log.SetLevel(log.DebugLevel)
 	}
 
-	http.Serve(l, dc.configureRouter())
+	srv := http.Server{Handler: dc.configureRouter()}
+	srv.SetKeepAlivesEnabled(false)
+	srv.Serve(l)
 	return l.Close()
 }
 


### PR DESCRIPTION
/cc @shaleman @vvb 

This fixes fd leaks caused by API hyperactivity in docker 1.10.