### PR TITLE
Stability enhancements

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -46,7 +46,7 @@ ansible_provision = proc do |ansible|
 
   # In a production deployment, these should be secret
   ansible.extra_vars = {
-    docker_version: "1.10.0",
+    docker_version: "1.10.1",
     etcd_peers_group: 'volplugin-test',
     env: proxy_env,
     fsid: '4a158d27-f750-41d5-9e7f-26ce4c9d2d45',

--- a/storage/backend/ceph/ceph.go
+++ b/storage/backend/ceph/ceph.go
@@ -11,7 +11,6 @@ import (
 	"syscall"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"golang.org/x/sys/unix"
 
 	"github.com/contiv/volplugin/executor"
@@ -69,19 +68,10 @@ func (c *Driver) Create(do storage.DriverOptions) error {
 	return nil
 }
 
-func (c *Driver) unlockAndLog(do storage.DriverOptions) {
-	// this call might fail, so we don't check the error here. It does log it's
-	// failures, however.
-	if err := c.unlockImage(do); err != nil {
-		log.Error(err)
-	}
-}
-
 // Format formats a created volume.
 func (c *Driver) Format(do storage.DriverOptions) error {
 	device, err := c.mapImage(do)
 	if err != nil {
-		c.unlockAndLog(do)
 		return err
 	}
 
@@ -150,7 +140,6 @@ func (c *Driver) Mount(do storage.DriverOptions) (*storage.Mount, error) {
 
 	devName, err := c.mapImage(do)
 	if err != nil {
-		c.unlockAndLog(do)
 		return nil, err
 	}
 

--- a/storage/backend/ceph/ceph_test.go
+++ b/storage/backend/ceph/ceph_test.go
@@ -1,10 +1,8 @@
 package ceph
 
 import (
-	"encoding/json"
 	"io"
 	"os"
-	"os/exec"
 	"strings"
 	. "testing"
 	"time"
@@ -198,25 +196,6 @@ func (s *cephSuite) TestMounted(c *C) {
 		},
 	})
 
-	output, err := exec.Command("sudo", "rbd", "lock", "--format", "json", "list", driverOpts.Volume.Name, "--pool", "rbd").Output()
-	c.Assert(err, IsNil)
-
-	locks := map[string]map[string]string{}
-	c.Assert(json.Unmarshal(output, &locks), IsNil)
-
-	_, ok := locks[driverOpts.Volume.Name]
-	c.Assert(ok, Equals, true)
-
 	c.Assert(driver.Unmount(driverOpts), IsNil)
-
-	output, err = exec.Command("sudo", "rbd", "lock", "--format", "json", "list", driverOpts.Volume.Name, "--pool", "rbd").Output()
-	c.Assert(err, IsNil)
-
-	locks = map[string]map[string]string{}
-	c.Assert(json.Unmarshal(output, &locks), IsNil)
-
-	_, ok = locks[driverOpts.Volume.Name]
-	c.Assert(ok, Equals, false)
-
 	c.Assert(driver.Destroy(driverOpts), IsNil)
 }


### PR DESCRIPTION
This *removes* RBD locking and instead relies on our etcd locking strategy. RBD locks were in some situations unremovable, so I figured this was the best solution for now.

This also brings a few more enhancements to the tests while debugging this, and an upgrade to docker 1.10.1 in the ansible.