### PR TITLE
Makefile: increase unit test time to 240m

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ run-build: godep
 
 system-test: build godep
 	rm -rf Godeps/_workspace/pkg
-	godep go test -v -timeout 120m ./systemtests -check.v
+	godep go test -v -timeout 240m ./systemtests -check.v
 
 reflex:
 	@echo 'To use this task, `go get github.com/cespare/reflex`'


### PR DESCRIPTION
the new FD test times out on jenkins. I'm going to merge this immediately so it does not break the rest of our tests.