### PR TITLE
Metacharacter management

### DIFF
--- a/storage/backend/ceph/ceph.go
+++ b/storage/backend/ceph/ceph.go
@@ -40,6 +40,27 @@ func NewDriver() storage.Driver {
 	return &Driver{}
 }
 
+// InternalName translates a volplugin `tenant/volume` name to an internal
+// name suitable for the driver. Yields an error if impossible.
+func (c *Driver) InternalName(s string) (string, error) {
+	strs := strings.SplitN(s, "/", 2)
+	if strings.Contains(strs[0], ".") {
+		return "", fmt.Errorf("Invalid tenant name %q, cannot contain '.'", strs[0])
+	}
+
+	if strings.Contains(strs[1], "/") {
+		return "", fmt.Errorf("Invalid volume name %q, cannot contain '/'", strs[0])
+	}
+
+	return strings.Join(strs, "."), nil
+}
+
+// InternalNameToVolpluginName translates an internal name to a volplugin
+// `tenant/volume` syntax name.
+func (c *Driver) InternalNameToVolpluginName(s string) string {
+	return strings.Join(strings.SplitN(s, ".", 2), "/")
+}
+
 // Create a volume.
 func (c *Driver) Create(do storage.DriverOptions) error {
 	poolName := do.Volume.Params["pool"]

--- a/storage/backend/ceph/ceph_test.go
+++ b/storage/backend/ceph/ceph_test.go
@@ -199,3 +199,25 @@ func (s *cephSuite) TestMounted(c *C) {
 	c.Assert(driver.Unmount(driverOpts), IsNil)
 	c.Assert(driver.Destroy(driverOpts), IsNil)
 }
+
+func (s *cephSuite) TestInternalNames(c *C) {
+	driver := NewDriver()
+	out, err := driver.InternalName("tenant1/test")
+	c.Assert(err, IsNil)
+	c.Assert(out, Equals, "tenant1.test")
+
+	out, err = driver.InternalName("tenant1.test/test")
+	c.Assert(err, NotNil)
+	c.Assert(out, Equals, "")
+
+	out, err = driver.InternalName("tenant1/test.two")
+	c.Assert(err, IsNil)
+	c.Assert(out, Equals, "tenant1.test.two")
+
+	out, err = driver.InternalName("tenant1/test/two")
+	c.Assert(err, NotNil)
+	c.Assert(out, Equals, "")
+
+	c.Assert(driver.InternalNameToVolpluginName("tenant1.test"), Equals, "tenant1/test")
+	c.Assert(driver.InternalNameToVolpluginName("tenant1.test.two"), Equals, "tenant1/test.two")
+}

--- a/storage/driver.go
+++ b/storage/driver.go
@@ -85,7 +85,15 @@ type Driver interface {
 	// of snapshots to be returned. Any error will be returned.
 	ListSnapshots(DriverOptions) ([]string, error)
 
-	// ShowMapped shows any volumes that belong to volplugin on the host, in
+	// Mounted shows any volumes that belong to volplugin on the host, in
 	// their native representation. They yield a *Mount.
 	Mounted(time.Duration) ([]*Mount, error)
+
+	// InternalName translates a volplugin `tenant/volume` name to an internal
+	// name suitable for the driver. Yields an error if impossible.
+	InternalName(string) (string, error)
+
+	// InternalNameToVolpluginName translates an internal name to a volplugin
+	// `tenant/volume` syntax name.
+	InternalNameToVolpluginName(s string) string
 }

--- a/volplugin/utils.go
+++ b/volplugin/utils.go
@@ -196,10 +196,6 @@ func splitPath(name string) (string, string, error) {
 	return parts[0], parts[1], nil
 }
 
-func joinPath(tenant, name string) string {
-	return strings.Join([]string{tenant, name}, ".")
-}
-
 func addStopChan(name string) chan struct{} {
 	mountMutex.Lock()
 	defer mountMutex.Unlock()


### PR DESCRIPTION
These patches push the management of metacharacters other than `/` down to the storage driver so they can deal with it.

fixes #75 