### PR TITLE
Add a null/no-op volume driver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ node_modules
 dist
 docs/docs
 .DS_Store
+*.swp
+cscope.*

--- a/config/global_test.go
+++ b/config/global_test.go
@@ -10,6 +10,7 @@ func (s *configSuite) TestGlobal(c *C) {
 		Debug:   true,
 		TTL:     10,
 		Timeout: 1,
+		Backend: "foo",
 	}
 
 	c.Assert(s.tlc.PublishGlobal(global), IsNil)
@@ -25,6 +26,7 @@ func (s *configSuite) TestGlobalWatch(c *C) {
 		Debug:   true,
 		TTL:     10,
 		Timeout: 1,
+		Backend: "foo",
 	}
 
 	// XXX this leaks but w/e, we should probably implement a stop chan. not a

--- a/config/policy.go
+++ b/config/policy.go
@@ -16,6 +16,15 @@ type PolicyConfig struct {
 	FileSystems          map[string]string `json:"filesystems"`
 }
 
+// NewPolicyConfig return policy config with specified backend preset
+func NewPolicyConfig(backend string) *PolicyConfig {
+	return &PolicyConfig{
+		DefaultVolumeOptions: VolumeOptions{
+			Backend: backend,
+		},
+	}
+}
+
 var defaultFilesystems = map[string]string{
 	"ext4": "mkfs.ext4 -m0 %",
 }

--- a/config/volume.go
+++ b/config/volume.go
@@ -28,6 +28,7 @@ type VolumeOptions struct {
 	FileSystem   string          `json:"filesystem" merge:"filesystem"`
 	Ephemeral    bool            `json:"ephemeral,omitempty" merge:"ephemeral"`
 	RateLimit    RateLimitConfig `json:"rate-limit,omitempty"`
+	Backend      string          `json:"backend"`
 
 	actualSize units.Base2Bytes
 }

--- a/storage/backend/backends.go
+++ b/storage/backend/backends.go
@@ -1,0 +1,23 @@
+package backend
+
+import (
+	"fmt"
+
+	"github.com/contiv/volplugin/storage"
+	"github.com/contiv/volplugin/storage/backend/ceph"
+	"github.com/contiv/volplugin/storage/backend/null"
+)
+
+// NewDriver instantiates and return a storage backend instance of the specified type
+func NewDriver(backend string) (storage.Driver, error) {
+	drivers := map[string]func() storage.Driver{
+		ceph.BackendName: ceph.NewDriver,
+		null.BackendName: null.NewDriver,
+	}
+
+	f, ok := drivers[backend]
+	if !ok {
+		return nil, fmt.Errorf("invalid driver backend: %q", backend)
+	}
+	return f(), nil
+}

--- a/storage/backend/ceph/ceph.go
+++ b/storage/backend/ceph/ceph.go
@@ -20,6 +20,8 @@ import (
 const (
 	deviceBase = "/dev/rbd"
 	mountBase  = "/mnt/ceph"
+	// BackendName is string for ceph storage backend
+	BackendName = "ceph"
 )
 
 var spaceSplitRegex = regexp.MustCompile(`\s+`)
@@ -38,6 +40,11 @@ type Driver struct{}
 // framework to yield new drivers on every creation.
 func NewDriver() storage.Driver {
 	return &Driver{}
+}
+
+// Name returns the ceph backend string
+func (c *Driver) Name() string {
+	return BackendName
 }
 
 // InternalName translates a volplugin `tenant/volume` name to an internal

--- a/storage/backend/null/null.go
+++ b/storage/backend/null/null.go
@@ -1,0 +1,91 @@
+package null
+
+import (
+	"time"
+
+	"github.com/contiv/volplugin/storage"
+)
+
+// BackendName is string for no-op storage backend
+const BackendName = "null"
+
+// Driver implements a no-op storage driver for volplugin.
+//
+// This is intended for regressing volplugin
+type Driver struct{}
+
+// NewDriver is a generator for Driver structs. It is used by the storage
+// framework to yield new drivers on every creation.
+func NewDriver() storage.Driver {
+	return &Driver{}
+}
+
+// Name returns the null backend string
+func (d *Driver) Name() string {
+	return BackendName
+}
+
+// Create is a noop.
+func (d *Driver) Create(storage.DriverOptions) error {
+	return nil
+}
+
+// Format is a noop.
+func (d *Driver) Format(do storage.DriverOptions) error {
+	return nil
+}
+
+// Destroy is a noop.
+func (d *Driver) Destroy(do storage.DriverOptions) error {
+	return nil
+}
+
+// List Volumes returns empty list.
+func (d *Driver) List(lo storage.ListOptions) ([]storage.Volume, error) {
+	return []storage.Volume{}, nil
+}
+
+// Mount is a noop
+func (d *Driver) Mount(do storage.DriverOptions) (*storage.Mount, error) {
+	return nil, nil
+}
+
+// Unmount is a noop.
+func (d *Driver) Unmount(do storage.DriverOptions) error {
+	return nil
+}
+
+// Exists returns false always.
+func (d *Driver) Exists(do storage.DriverOptions) (bool, error) {
+	return false, nil
+}
+
+// CreateSnapshot is a noop.
+func (d *Driver) CreateSnapshot(s string, do storage.DriverOptions) error {
+	return nil
+}
+
+// RemoveSnapshot is a noop.
+func (d *Driver) RemoveSnapshot(s string, do storage.DriverOptions) error {
+	return nil
+}
+
+// ListSnapshots returns an empty list.
+func (d *Driver) ListSnapshots(do storage.DriverOptions) ([]string, error) {
+	return []string{}, nil
+}
+
+// Mounted retuns an empty list.
+func (d *Driver) Mounted(t time.Duration) ([]*storage.Mount, error) {
+	return []*storage.Mount{}, nil
+}
+
+// InternalName returns the passed string as is.
+func (d *Driver) InternalName(s string) (string, error) {
+	return s, nil
+}
+
+// InternalNameToVolpluginName returns the passed string as is.
+func (d *Driver) InternalNameToVolpluginName(s string) string {
+	return s
+}

--- a/storage/driver.go
+++ b/storage/driver.go
@@ -54,6 +54,9 @@ type Volume struct {
 // Consumers should do this through the NewStorage call and associated member
 // functions.
 type Driver interface {
+	// Name returns the string associated with the storage backed of the driver
+	Name() string
+
 	// Create a volume.
 	Create(DriverOptions) error
 

--- a/systemtests/init_test.go
+++ b/systemtests/init_test.go
@@ -65,6 +65,6 @@ func (s *systemtestSuite) SetUpSuite(c *C) {
 	c.Assert(s.pullDebian(), IsNil)
 	c.Assert(s.rebootstrap(), IsNil)
 
-	_, err = s.uploadIntent("policy1", "intent1")
-	c.Assert(err, IsNil)
+	out, err := s.uploadIntent("policy1", "intent1")
+	c.Assert(err, IsNil, Commentf("output: %s", out))
 }

--- a/systemtests/testdata/nulldriver.json
+++ b/systemtests/testdata/nulldriver.json
@@ -1,0 +1,12 @@
+{ 
+  "default-options": {
+    "pool": "rbd",
+    "size": "10MB",
+    "snapshots": true,
+    "snapshot": {
+      "frequency": "30m",
+      "keep": 20
+    },
+    "backend" : "null"
+  }
+}

--- a/systemtests/util_test.go
+++ b/systemtests/util_test.go
@@ -11,6 +11,7 @@ import (
 	utils "github.com/contiv/systemtests-utils"
 	"github.com/contiv/vagrantssh"
 	"github.com/contiv/volplugin/config"
+	"github.com/contiv/volplugin/storage/backend/ceph"
 )
 
 func (s *systemtestSuite) mon0cmd(command string) (string, error) {
@@ -31,7 +32,7 @@ func (s *systemtestSuite) readIntent(fn string) (*config.PolicyConfig, error) {
 		return nil, err
 	}
 
-	cfg := &config.PolicyConfig{}
+	cfg := config.NewPolicyConfig(ceph.BackendName)
 
 	if err := json.Unmarshal(content, cfg); err != nil {
 		return nil, err
@@ -146,7 +147,8 @@ func (s *systemtestSuite) rebootstrap() error {
 		return err
 	}
 
-	if _, err := s.uploadIntent("policy1", "intent1"); err != nil {
+	if out, err := s.uploadIntent("policy1", "intent1"); err != nil {
+		log.Errorf("Intent upload failed. Error: %v, Output: %s", err, out)
 		return err
 	}
 

--- a/systemtests/volmaster_test.go
+++ b/systemtests/volmaster_test.go
@@ -31,19 +31,19 @@ func (s *systemtestSuite) TestVolmasterGlobalConfigUpdate(c *C) {
 	content, err := ioutil.ReadFile("testdata/global1.json")
 	c.Assert(err, IsNil)
 
-	globalBase1 := &config.Global{}
+	globalBase1 := config.NewGlobalConfig()
 	c.Assert(json.Unmarshal(content, globalBase1), IsNil)
 
 	content, err = ioutil.ReadFile("testdata/global2.json")
 	c.Assert(err, IsNil)
 
-	globalBase2 := &config.Global{}
+	globalBase2 := config.NewGlobalConfig()
 	c.Assert(json.Unmarshal(content, globalBase2), IsNil)
 
 	out, err := s.volcli("global get")
 	c.Assert(err, IsNil)
 
-	global := &config.Global{}
+	global := config.NewGlobalConfig()
 	c.Assert(json.Unmarshal([]byte(out), global), IsNil)
 
 	c.Assert(globalBase1, DeepEquals, global)
@@ -54,7 +54,7 @@ func (s *systemtestSuite) TestVolmasterGlobalConfigUpdate(c *C) {
 	out, err = s.volcli("global get")
 	c.Assert(err, IsNil)
 
-	global = &config.Global{}
+	global = config.NewGlobalConfig()
 	c.Assert(json.Unmarshal([]byte(out), global), IsNil)
 
 	c.Assert(globalBase1, Not(DeepEquals), global)

--- a/volcli/commands.go
+++ b/volcli/commands.go
@@ -55,6 +55,7 @@ var Commands = []cli.Command{
 		Subcommands: []cli.Command{
 			{
 				Name:        "upload",
+				Flags:       VolmasterFlags,
 				ArgsUsage:   "[policy name]. accepts from stdin",
 				Description: "Uploads a policy to etcd. Accepts JSON. Requires direct, unauthenticated access to etcd.",
 				Usage:       "Upload a policy to etcd",

--- a/volcli/volcli_test.go
+++ b/volcli/volcli_test.go
@@ -117,6 +117,16 @@ func (s *volcliSuite) TestErrorReturns(c *C) {
 			args: []string{"foo"},
 			err:  errorInvalidVolumeSyntax("foo", `<policyName>/<volumeName>`),
 		},
+		"globalGet": {
+			f:    globalGet,
+			args: []string{"foo"},
+			err:  errorInvalidArgCount(1, 0, []string{"foo"}),
+		},
+		"globalUpload": {
+			f:    globalUpload,
+			args: []string{"foo"},
+			err:  errorInvalidArgCount(1, 0, []string{"foo"}),
+		},
 	}
 
 	for key, test := range testMap {

--- a/volmaster/daemon.go
+++ b/volmaster/daemon.go
@@ -53,7 +53,7 @@ func (d *DaemonConfig) Daemon(debug bool, listen string) {
 	if err != nil {
 		log.Errorf("Error fetching global configuration: %v", err)
 		log.Infof("No global configuration. Proceeding with defaults...")
-		global = &config.Global{TTL: config.DefaultGlobalTTL}
+		global = config.NewGlobalConfig()
 	}
 
 	d.Global = global

--- a/volmaster/volume.go
+++ b/volmaster/volume.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/contiv/volplugin/config"
 	"github.com/contiv/volplugin/storage"
-	"github.com/contiv/volplugin/storage/backend/ceph"
+	"github.com/contiv/volplugin/storage/backend"
 
 	log "github.com/Sirupsen/logrus"
 )
@@ -33,7 +33,11 @@ func createVolume(policy *config.PolicyConfig, config *config.VolumeConfig, time
 		return storage.DriverOptions{}, err
 	}
 
-	driver := ceph.NewDriver()
+	driver, err := backend.NewDriver(config.Options.Backend)
+	if err != nil {
+		return storage.DriverOptions{}, err
+	}
+
 	intName, err := driver.InternalName(config.String())
 	if err != nil {
 		return storage.DriverOptions{}, err
@@ -64,18 +68,24 @@ func formatVolume(config *config.VolumeConfig, do storage.DriverOptions) error {
 		return err
 	}
 
-	driver := ceph.NewDriver()
+	driver, err := backend.NewDriver(config.Options.Backend)
+	if err != nil {
+		return err
+	}
 	intName, err := driver.InternalName(config.String())
 	if err != nil {
 		return err
 	}
 
 	log.Infof("Formatting volume %q (pool %q, filesystem %q) with size %d", intName, config.Options.Pool, config.Options.FileSystem, actualSize)
-	return ceph.NewDriver().Format(do)
+	return driver.Format(do)
 }
 
 func removeVolume(config *config.VolumeConfig, timeout time.Duration) error {
-	driver := ceph.NewDriver()
+	driver, err := backend.NewDriver(config.Options.Backend)
+	if err != nil {
+		return err
+	}
 	intName, err := driver.InternalName(config.String())
 	if err != nil {
 		return err

--- a/volplugin/handlers.go
+++ b/volplugin/handlers.go
@@ -12,6 +12,7 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/contiv/volplugin/config"
 	"github.com/contiv/volplugin/storage"
+	"github.com/contiv/volplugin/storage/backend"
 	"github.com/contiv/volplugin/storage/backend/ceph"
 	"github.com/docker/docker/pkg/plugins"
 )
@@ -154,7 +155,12 @@ func remove(master string) func(http.ResponseWriter, *http.Request) {
 			}
 		}
 
-		driver := ceph.NewDriver()
+		driver, err := backend.NewDriver(vc.Options.Backend)
+		if err != nil {
+			httpError(w, fmt.Sprintf("loading driver"), err)
+			return
+		}
+
 		name, err := driver.InternalName(uc.Request.Name)
 		if err != nil {
 			httpError(w, fmt.Sprintf("Removing volume %q", uc.Request.Name), err)
@@ -217,7 +223,11 @@ func mount(master, host string, ttl time.Duration) func(http.ResponseWriter, *ht
 			return
 		}
 
-		driver := ceph.NewDriver()
+		driver, err := backend.NewDriver(volConfig.Options.Backend)
+		if err != nil {
+			httpError(w, fmt.Sprintf("loading driver"), err)
+			return
+		}
 
 		ut := &config.UseConfig{
 			Volume:   volConfig,
@@ -290,7 +300,12 @@ func unmount(master, host string) func(http.ResponseWriter, *http.Request) {
 			return
 		}
 
-		driver := ceph.NewDriver()
+		driver, err := backend.NewDriver(volConfig.Options.Backend)
+		if err != nil {
+			httpError(w, fmt.Sprintf("loading driver"), err)
+			return
+		}
+
 		intName, err := driver.InternalName(uc.Request.Name)
 		if err != nil {
 			httpError(w, fmt.Sprintf("Volume %q does not satisfy name requirements", uc.Request.Name), err)

--- a/volplugin/volplugin.go
+++ b/volplugin/volplugin.go
@@ -150,7 +150,7 @@ func (dc *DaemonConfig) getGlobal() {
 		return
 	}
 
-	global := &config.Global{}
+	global := config.NewGlobalConfig()
 
 	if err := json.Unmarshal(content, global); err != nil {
 		log.Errorf("Could not request global configuration: %v", err)

--- a/volsupervisor/snapshots.go
+++ b/volsupervisor/snapshots.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/contiv/volplugin/config"
 	"github.com/contiv/volplugin/storage"
-	"github.com/contiv/volplugin/storage/backend/ceph"
+	"github.com/contiv/volplugin/storage/backend"
 
 	log "github.com/Sirupsen/logrus"
 )
@@ -40,7 +40,11 @@ func (dc *DaemonConfig) scheduleSnapshotPrune() {
 func (dc *DaemonConfig) runSnapshotPrune(pool string, volume *config.VolumeConfig) {
 	log.Debugf("starting snapshot prune for %q", volume.VolumeName)
 
-	driver := ceph.NewDriver()
+	driver, err := backend.NewDriver(volume.Options.Backend)
+	if err != nil {
+		log.Errorf("failed to get driver: %v", err)
+		return
+	}
 
 	driverOpts := storage.DriverOptions{
 		Volume: storage.Volume{
@@ -74,7 +78,11 @@ func (dc *DaemonConfig) runSnapshotPrune(pool string, volume *config.VolumeConfi
 func (dc *DaemonConfig) runSnapshot(pool string, volume *config.VolumeConfig) {
 	now := time.Now()
 	log.Infof("Snapping volume %q at %v", volume, now)
-	driver := ceph.NewDriver()
+	driver, err := backend.NewDriver(volume.Options.Backend)
+	if err != nil {
+		log.Errorf("failed to get driver: %v", err)
+		return
+	}
 	driverOpts := storage.DriverOptions{
 		Volume: storage.Volume{
 			Name: strings.Join([]string{volume.PolicyName, volume.VolumeName}, "."),


### PR DESCRIPTION
The changes here introduce a null driver that basically doesn't perform any actual disk operations.

The driver to use for a volume is set in `volume-options` using field called `backend`. The default backend is `ceph` and a user can override it by specifying the `backend` field in `default-options` structure.

The primary use case of the null driver will be to use it in scale/battery tests to exercise/benchmark volplugin alone  and I plan to work on that next. But I put out this PR to make sure I am working in right direction and also to keep the patch small.

fixes #153 

@erikh @unclejack PTAL