### PR TITLE
Mountpoint global

### DIFF
--- a/config/global_test.go
+++ b/config/global_test.go
@@ -7,10 +7,11 @@ func (s *configSuite) TestGlobal(c *C) {
 	c.Assert(err, NotNil)
 
 	global := &Global{
-		Debug:   true,
-		TTL:     10,
-		Timeout: 1,
-		Backend: "foo",
+		Debug:     true,
+		TTL:       10,
+		Timeout:   1,
+		Backend:   "foo",
+		MountPath: defaultMountPath,
 	}
 
 	c.Assert(s.tlc.PublishGlobal(global), IsNil)
@@ -19,14 +20,26 @@ func (s *configSuite) TestGlobal(c *C) {
 	c.Assert(global, DeepEquals, DivideGlobalParameters(global2))
 }
 
+func (s *configSuite) TestGlobalEmpty(c *C) {
+	c.Assert(s.tlc.PublishGlobal(&Global{}), IsNil)
+	global, err := s.tlc.GetGlobal()
+	c.Assert(err, IsNil)
+
+	c.Assert(global, DeepEquals, &Global{
+		TTL:       DefaultGlobalTTL,
+		MountPath: defaultMountPath,
+	})
+}
+
 func (s *configSuite) TestGlobalWatch(c *C) {
 	activity := make(chan *Global)
 
 	global := &Global{
-		Debug:   true,
-		TTL:     10,
-		Timeout: 1,
-		Backend: "foo",
+		Debug:     true,
+		TTL:       10,
+		Timeout:   1,
+		Backend:   "foo",
+		MountPath: defaultMountPath,
 	}
 
 	// XXX this leaks but w/e, we should probably implement a stop chan. not a

--- a/lock/client/client.go
+++ b/lock/client/client.go
@@ -85,8 +85,6 @@ func (d *Driver) reportMountEndpoint(endpoint string, ut *config.UseMount) error
 		return err
 	}
 
-	fmt.Printf("%#v\n", d)
-
 	resp, err := http.Post(fmt.Sprintf("http://%s/%s", d.master, endpoint), "application/json", bytes.NewBuffer(content))
 	if err != nil {
 		return err

--- a/storage/backend/backends.go
+++ b/storage/backend/backends.go
@@ -8,16 +8,17 @@ import (
 	"github.com/contiv/volplugin/storage/backend/null"
 )
 
-// NewDriver instantiates and return a storage backend instance of the specified type
-func NewDriver(backend string) (storage.Driver, error) {
-	drivers := map[string]func() storage.Driver{
-		ceph.BackendName: ceph.NewDriver,
-		null.BackendName: null.NewDriver,
-	}
+// Drivers is the map of string to storage.Driver.
+var Drivers = map[string]func(string) storage.Driver{
+	ceph.BackendName: ceph.NewDriver,
+	null.BackendName: null.NewDriver,
+}
 
-	f, ok := drivers[backend]
+// NewDriver instantiates and return a storage backend instance of the specified type
+func NewDriver(backend, mountpath string) (storage.Driver, error) {
+	f, ok := Drivers[backend]
 	if !ok {
 		return nil, fmt.Errorf("invalid driver backend: %q", backend)
 	}
-	return f(), nil
+	return f(mountpath), nil
 }

--- a/storage/backend/ceph/util.go
+++ b/storage/backend/ceph/util.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/contiv/volplugin/executor"
+	"github.com/contiv/volplugin/storage"
 )
 
 func (c *Driver) poolExists(poolName string) (bool, error) {
@@ -31,8 +32,8 @@ func (c *Driver) poolExists(poolName string) (bool, error) {
 }
 
 // MountPath returns the path of a mount for a pool/volume.
-func MountPath(poolName, volumeName string) string {
-	return filepath.Join(mountBase, poolName, volumeName)
+func (c *Driver) MountPath(do storage.DriverOptions) string {
+	return filepath.Join(c.mountpath, do.Volume.Params["pool"], do.Volume.Name)
 }
 
 // FIXME maybe this belongs in storage/ as it's more general?

--- a/storage/backend/null/null.go
+++ b/storage/backend/null/null.go
@@ -1,6 +1,7 @@
 package null
 
 import (
+	"path/filepath"
 	"time"
 
 	"github.com/contiv/volplugin/storage"
@@ -12,12 +13,14 @@ const BackendName = "null"
 // Driver implements a no-op storage driver for volplugin.
 //
 // This is intended for regressing volplugin
-type Driver struct{}
+type Driver struct {
+	mountpath string
+}
 
 // NewDriver is a generator for Driver structs. It is used by the storage
 // framework to yield new drivers on every creation.
-func NewDriver() storage.Driver {
-	return &Driver{}
+func NewDriver(mountpath string) storage.Driver {
+	return &Driver{mountpath: mountpath}
 }
 
 // Name returns the null backend string
@@ -88,4 +91,9 @@ func (d *Driver) InternalName(s string) (string, error) {
 // InternalNameToVolpluginName returns the passed string as is.
 func (d *Driver) InternalNameToVolpluginName(s string) string {
 	return s
+}
+
+// MountPath describes the path at which the volume should be mounted.
+func (d *Driver) MountPath(do storage.DriverOptions) string {
+	return filepath.Join(d.mountpath, do.Volume.Name)
 }

--- a/storage/driver.go
+++ b/storage/driver.go
@@ -98,5 +98,8 @@ type Driver interface {
 
 	// InternalNameToVolpluginName translates an internal name to a volplugin
 	// `tenant/volume` syntax name.
-	InternalNameToVolpluginName(s string) string
+	InternalNameToVolpluginName(string) string
+
+	// MountPath describes the path at which the volume should be mounted.
+	MountPath(DriverOptions) string
 }

--- a/systemtests/testdata/mountpath_global.json
+++ b/systemtests/testdata/mountpath_global.json
@@ -1,0 +1,1 @@
+{"MountPath": "/mnt/test"}

--- a/systemtests/volplugin_test.go
+++ b/systemtests/volplugin_test.go
@@ -83,3 +83,12 @@ func (s *systemtestSuite) TestVolpluginHostLabel(c *C) {
 	c.Assert(json.Unmarshal([]byte(out), ut), IsNil)
 	c.Assert(ut.Hostname, Equals, "quux")
 }
+
+func (s *systemtestSuite) TestVolpluginMountPath(c *C) {
+	c.Assert(s.uploadGlobal("mountpath_global"), IsNil)
+	time.Sleep(1 * time.Second)
+	c.Assert(s.createVolume("mon0", "policy1", "test", nil), IsNil)
+	_, err := s.docker("run -d -v policy1/test:/mnt alpine sleep 10m")
+	c.Assert(err, IsNil)
+	c.Assert(s.vagrant.GetNode("mon0").RunCommand("sudo test -d /mnt/test/rbd/policy1.test"), IsNil)
+}

--- a/volmaster/volume.go
+++ b/volmaster/volume.go
@@ -13,7 +13,7 @@ import (
 
 const defaultFsCmd = "mkfs.ext4 -m0 %"
 
-func createVolume(policy *config.PolicyConfig, config *config.VolumeConfig, timeout time.Duration) (storage.DriverOptions, error) {
+func (dc *DaemonConfig) createVolume(policy *config.PolicyConfig, config *config.VolumeConfig, timeout time.Duration) (storage.DriverOptions, error) {
 	var (
 		fscmd string
 		ok    bool
@@ -33,7 +33,7 @@ func createVolume(policy *config.PolicyConfig, config *config.VolumeConfig, time
 		return storage.DriverOptions{}, err
 	}
 
-	driver, err := backend.NewDriver(config.Options.Backend)
+	driver, err := backend.NewDriver(config.Options.Backend, dc.Global.MountPath)
 	if err != nil {
 		return storage.DriverOptions{}, err
 	}
@@ -62,13 +62,13 @@ func createVolume(policy *config.PolicyConfig, config *config.VolumeConfig, time
 	return driverOpts, driver.Create(driverOpts)
 }
 
-func formatVolume(config *config.VolumeConfig, do storage.DriverOptions) error {
+func (dc *DaemonConfig) formatVolume(config *config.VolumeConfig, do storage.DriverOptions) error {
 	actualSize, err := config.Options.ActualSize()
 	if err != nil {
 		return err
 	}
 
-	driver, err := backend.NewDriver(config.Options.Backend)
+	driver, err := backend.NewDriver(config.Options.Backend, dc.Global.MountPath)
 	if err != nil {
 		return err
 	}
@@ -81,8 +81,8 @@ func formatVolume(config *config.VolumeConfig, do storage.DriverOptions) error {
 	return driver.Format(do)
 }
 
-func removeVolume(config *config.VolumeConfig, timeout time.Duration) error {
-	driver, err := backend.NewDriver(config.Options.Backend)
+func (dc *DaemonConfig) removeVolume(config *config.VolumeConfig, timeout time.Duration) error {
+	driver, err := backend.NewDriver(config.Options.Backend, dc.Global.MountPath)
 	if err != nil {
 		return err
 	}

--- a/volsupervisor/snapshots.go
+++ b/volsupervisor/snapshots.go
@@ -40,7 +40,7 @@ func (dc *DaemonConfig) scheduleSnapshotPrune() {
 func (dc *DaemonConfig) runSnapshotPrune(pool string, volume *config.VolumeConfig) {
 	log.Debugf("starting snapshot prune for %q", volume.VolumeName)
 
-	driver, err := backend.NewDriver(volume.Options.Backend)
+	driver, err := backend.NewDriver(volume.Options.Backend, dc.Global.MountPath)
 	if err != nil {
 		log.Errorf("failed to get driver: %v", err)
 		return
@@ -78,7 +78,7 @@ func (dc *DaemonConfig) runSnapshotPrune(pool string, volume *config.VolumeConfi
 func (dc *DaemonConfig) runSnapshot(pool string, volume *config.VolumeConfig) {
 	now := time.Now()
 	log.Infof("Snapping volume %q at %v", volume, now)
-	driver, err := backend.NewDriver(volume.Options.Backend)
+	driver, err := backend.NewDriver(volume.Options.Backend, dc.Global.MountPath)
 	if err != nil {
 		log.Errorf("failed to get driver: %v", err)
 		return


### PR DESCRIPTION
This provides the base mount point (hard-coded as a default previously as `/mnt/ceph`) as a configurable global.

I made some tests but I'm sorry for the size of this patch; it just touched everything.

Be aware this also depends on the #170 patch getting merged first.