### PR TITLE
volplugin,systemtests: ensure resiliency when the volmaster goes down and volplugin is starting.

### DIFF
--- a/systemtests/volplugin_test.go
+++ b/systemtests/volplugin_test.go
@@ -11,6 +11,14 @@ import (
 	log "github.com/Sirupsen/logrus"
 )
 
+func (s *systemtestSuite) TestVolpluginVolmasterDown(c *C) {
+	c.Assert(stopVolmaster(s.vagrant.GetNode("mon0")), IsNil)
+	c.Assert(stopVolplugin(s.vagrant.GetNode("mon0")), IsNil)
+	c.Assert(startVolplugin(s.vagrant.GetNode("mon0")), IsNil)
+	c.Assert(startVolmaster(s.vagrant.GetNode("mon0")), IsNil)
+	c.Assert(s.createVolume("mon0", "policy1", "test", nil), IsNil)
+}
+
 func (s *systemtestSuite) TestVolpluginCleanupSocket(c *C) {
 	c.Assert(stopVolplugin(s.vagrant.GetNode("mon0")), IsNil)
 	defer c.Assert(startVolplugin(s.vagrant.GetNode("mon0")), IsNil)

--- a/volplugin/volplugin.go
+++ b/volplugin/volplugin.go
@@ -56,11 +56,18 @@ type volumeGet struct {
 func (dc *DaemonConfig) Daemon() error {
 	dc.Client = client.NewDriver(dc.Master)
 
-	dc.getGlobal()
+	for {
+		dc.getGlobal()
 
-	if dc.Global == nil {
-		log.Fatal("Global configuration is missing; aborting.")
+		if dc.Global != nil {
+			break
+		}
+
+		log.Errorf("Global configuration is missing; waiting for volmaster at %q.", dc.Master)
+		time.Sleep(1 * time.Second)
 	}
+
+	log.Infof("Reached volmaster at %q. Continuing startup.", dc.Master)
 
 	if err := dc.updateMounts(); err != nil {
 		return err


### PR DESCRIPTION
this makes volplugin wait unitl the volmaster starts to attempt doing anything else. it logs the result of whether or not it contacted its volmaster.

depends on #171 and #147 being merged first. check the last commit for the meat.

@mapuri @unclejack 