### PR TITLE
Watch

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"path"
 
+	"github.com/contiv/volplugin/watch"
 	"github.com/coreos/etcd/client"
 	"golang.org/x/net/context"
 )
@@ -55,6 +56,8 @@ func NewTopLevelConfig(prefix string, etcdHosts []string) (*TopLevelConfig, erro
 		prefix:     prefix,
 		etcdClient: client.NewKeysAPI(etcdClient),
 	}
+
+	watch.Init(config.etcdClient)
 
 	config.etcdClient.Set(context.Background(), config.prefix, "", &client.SetOptions{Dir: true})
 	for _, path := range defaultPaths {

--- a/config/global_test.go
+++ b/config/global_test.go
@@ -44,7 +44,7 @@ func (s *configSuite) TestGlobalWatch(c *C) {
 
 	// XXX this leaks but w/e, we should probably implement a stop chan. not a
 	// real world problem
-	go s.tlc.WatchGlobal(activity)
+	s.tlc.WatchGlobal(activity)
 
 	c.Assert(s.tlc.PublishGlobal(global), IsNil)
 	global2 := DivideGlobalParameters(<-activity)

--- a/volmaster/daemon.go
+++ b/volmaster/daemon.go
@@ -63,7 +63,7 @@ func (d *DaemonConfig) Daemon(debug bool, listen string) {
 	go info.HandleDebugSignal()
 
 	activity := make(chan *config.Global)
-	go d.Config.WatchGlobal(activity)
+	d.Config.WatchGlobal(activity)
 	go func() {
 		for {
 			d.Global = <-activity

--- a/volsupervisor/daemon.go
+++ b/volsupervisor/daemon.go
@@ -35,7 +35,7 @@ func (dc *DaemonConfig) Daemon() {
 	dc.setDebug()
 
 	globalChan := make(chan *config.Global)
-	go dc.Config.WatchGlobal(globalChan)
+	dc.Config.WatchGlobal(globalChan)
 	go func() {
 		for {
 			dc.Global = <-globalChan

--- a/watch/watch.go
+++ b/watch/watch.go
@@ -1,0 +1,128 @@
+// Package watch is a singleton registry of path -> etcd watches. It does the
+// watching in a uniform manner, and uses provided functions to perform the
+// specific work.
+package watch
+
+import (
+	"sync"
+	"time"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/coreos/etcd/client"
+	"golang.org/x/net/context"
+)
+
+// WatcherFunc is the function that's fired anytime the watch recieves an event
+// that is not an error. It is expected that the WatcherFunc send to the
+// channel on success.
+type WatcherFunc func(*client.Node, *Watcher)
+
+// Watcher is a struct that describes the various channels and data that
+// comprise a successful watch on etcd.
+//
+// Note in particular the Channel, which is an interface{}. The channel must be
+// of type `chan` and it is expected that a listener exists for that channel
+// elsewhere.
+type Watcher struct {
+	WatcherFunc
+	Path         string
+	Channel      interface{}
+	StopChannel  chan struct{}
+	ErrorChannel chan error
+	StopOnError  bool
+	Recursive    bool
+}
+
+var etcdClient client.KeysAPI
+
+var (
+	watchers     = map[string][]*Watcher{}
+	watcherMutex = sync.Mutex{}
+)
+
+// Init must be called before any watches can be established. Any attempt to
+// create a watch before this is called will not yield an error but just log
+// instead, without creating the watch. This should always be called before
+// you're ready to use watches.
+func Init(ec client.KeysAPI) {
+	etcdClient = ec
+}
+
+// NewWatcher creates a basic Watcher with the channel, path, and WatcherFunc.
+// NewWatcher will create the other channels and set recursive.
+func NewWatcher(channel interface{}, path string, fun WatcherFunc) *Watcher {
+	return &Watcher{
+		WatcherFunc:  fun,
+		Channel:      channel,
+		Path:         path,
+		StopChannel:  make(chan struct{}, 1),
+		ErrorChannel: make(chan error, 1),
+		Recursive:    true,
+	}
+}
+
+// Create a watch. Given a watcher, creates a watch and runs it in a goroutine,
+// then registers it with the watch registry.
+func Create(w *Watcher) {
+	if etcdClient == nil {
+		log.Error("etcdClient is nil, cannot watch anything!")
+		return
+	}
+
+	watcherMutex.Lock()
+	defer watcherMutex.Unlock()
+
+	go func(w *Watcher) {
+		watcher := etcdClient.Watcher(w.Path, &client.WatcherOptions{Recursive: w.Recursive})
+
+		ctx, cancel := context.WithCancel(context.Background())
+		go func() {
+			<-w.StopChannel
+			cancel()
+		}()
+
+		for {
+			resp, err := watcher.Next(ctx)
+			if err != nil {
+				if err == context.Canceled {
+					log.Debugf("watch for %q canceled", w.Path)
+					return
+				}
+
+				w.ErrorChannel <- err
+				if w.StopOnError {
+					w.StopChannel <- struct{}{}
+					return
+				}
+
+				time.Sleep(1 * time.Second)
+				continue
+			}
+
+			w.WatcherFunc(resp.Node, w)
+		}
+	}(w)
+
+	wary, ok := watchers[w.Path]
+	if !ok {
+		wary = []*Watcher{}
+		watchers[w.Path] = wary
+	}
+	watchers[w.Path] = append(watchers[w.Path], w)
+}
+
+// Stop a watch. Given a path, stops all the watchers for a given path (f.e., it expired).
+func Stop(path string) {
+	watcherMutex.Lock()
+	defer watcherMutex.Unlock()
+
+	if _, ok := watchers[path]; !ok {
+		return
+	}
+
+	for _, w := range watchers[path] {
+		w.StopChannel <- struct{}{}
+	}
+
+	delete(watchers, path)
+}

--- a/watch/watch_test.go
+++ b/watch/watch_test.go
@@ -1,0 +1,87 @@
+package watch
+
+import (
+	"fmt"
+	"os/exec"
+
+	"golang.org/x/net/context"
+
+	. "testing"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/coreos/etcd/client"
+)
+
+type watchSuite struct{}
+
+var _ = Suite(&watchSuite{})
+
+func TestWatch(t *T) { TestingT(t) }
+
+func setKey(path, value string) {
+	etcdClient.Set(context.Background(), path, value, nil)
+}
+
+func (s *watchSuite) SetUpTest(c *C) {
+	exec.Command("/bin/sh", "-c", "etcdctl rm --recursive /watch").Run()
+
+	etcdCfg := client.Config{
+		Endpoints: []string{"http://127.0.0.1:2379"},
+	}
+
+	etcdClient, err := client.New(etcdCfg)
+	c.Assert(err, IsNil)
+
+	Init(client.NewKeysAPI(etcdClient))
+}
+
+func (s *watchSuite) TestBasic(c *C) {
+	w := NewWatcher(make(chan bool), "/watch", func(node *client.Node, w *Watcher) {
+		w.Channel.(chan bool) <- true
+	})
+
+	Create(w)
+
+	val, ok := watchers["/watch"]
+	c.Assert(ok, Equals, true)
+	c.Assert(val, NotNil)
+
+	for i := 0; i < 10; i++ {
+		setKey(fmt.Sprintf("/watch/test%d", i), "")
+	}
+
+	select {
+	case err := <-w.ErrorChannel:
+		c.Assert(err, IsNil) // won't ever pass, but at least we'll get the message this way
+	default:
+	}
+
+	for i := 0; i < 10; i++ {
+		c.Assert(<-w.Channel.(chan bool), Equals, true)
+	}
+
+	Stop(w.Path)
+
+	for i := 0; i < 10; i++ {
+		setKey(fmt.Sprintf("/watch/test%d", i), "")
+	}
+
+	select {
+	case err := <-w.ErrorChannel:
+		c.Assert(err, IsNil) // won't be, but at least we'll get the message this way
+	default:
+	}
+
+	var x = 0
+
+	for i := 0; i < 10; i++ {
+		select {
+		case <-w.Channel.(chan bool):
+			x++
+		default:
+		}
+	}
+
+	c.Assert(x, Equals, 0)
+}


### PR DESCRIPTION
This provides a high-level interface to etcd watches and ports WatchGlobal to use it.

Will be used by an upcoming volsupervisor rewrite.