### PR TITLE
Volume snapshot copy

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -23,8 +23,9 @@ var ErrExist = errors.New("Already exists")
 // Request provides a request structure for communicating with the
 // volmaster.
 type Request struct {
-	Volume string `json:"volume"`
-	Policy string `json:"policy"`
+	Volume  string `json:"volume"`
+	Policy  string `json:"policy"`
+	Options map[string]string
 }
 
 // RequestCreate provides a request structure for creating new volumes.

--- a/lock/lock.go
+++ b/lock/lock.go
@@ -38,6 +38,8 @@ const (
 	// ReasonSnapshotPrune is the prune operation for snapshots
 	ReasonSnapshotPrune = "SnapshotPrune"
 
+	// ReasonCopy indicates a copy from snapshot operation.
+	ReasonCopy = "Copy"
 	// ReasonMaintenance indicates that an operator is acquiring the lock.
 	ReasonMaintenance = "Maintenance"
 )

--- a/storage/backend/null/null.go
+++ b/storage/backend/null/null.go
@@ -73,6 +73,11 @@ func (d *Driver) RemoveSnapshot(s string, do storage.DriverOptions) error {
 	return nil
 }
 
+// CopySnapshot is a noop.
+func (d *Driver) CopySnapshot(do storage.DriverOptions, s, s2 string) error {
+	return nil
+}
+
 // ListSnapshots returns an empty list.
 func (d *Driver) ListSnapshots(do storage.DriverOptions) ([]string, error) {
 	return []string{}, nil

--- a/storage/driver.go
+++ b/storage/driver.go
@@ -88,6 +88,10 @@ type Driver interface {
 	// of snapshots to be returned. Any error will be returned.
 	ListSnapshots(DriverOptions) ([]string, error)
 
+	// CopySnapshot copies a snapshot into a new volume. Takes a DriverOptions,
+	// snap and volume name (string). Returns error on failure.
+	CopySnapshot(DriverOptions, string, string) error
+
 	// Mounted shows any volumes that belong to volplugin on the host, in
 	// their native representation. They yield a *Mount.
 	Mounted(time.Duration) ([]*Mount, error)

--- a/systemtests/testdata/fastsnap.json
+++ b/systemtests/testdata/fastsnap.json
@@ -4,7 +4,7 @@
     "size": "10MB",
     "snapshots": true,
     "snapshot": {
-      "frequency": "1s",
+      "frequency": "2s",
       "keep": 5
     }
   }

--- a/systemtests/volsupervisor_test.go
+++ b/systemtests/volsupervisor_test.go
@@ -12,7 +12,7 @@ func (s *systemtestSuite) TestVolsupervisorSnapshotSchedule(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(s.createVolume("mon0", "policy1", "foo", nil), IsNil)
 
-	time.Sleep(2 * time.Second)
+	time.Sleep(4 * time.Second)
 
 	out, err := s.vagrant.GetNode("mon0").RunCommandWithOutput("sudo rbd snap ls policy1.foo")
 	c.Assert(err, IsNil)
@@ -32,7 +32,7 @@ func (s *systemtestSuite) TestVolsupervisorStopStartSnapshot(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(s.createVolume("mon0", "policy1", "foo", nil), IsNil)
 
-	time.Sleep(2 * time.Second)
+	time.Sleep(4 * time.Second)
 
 	out, err := s.vagrant.GetNode("mon0").RunCommandWithOutput("sudo rbd snap ls policy1.foo")
 	c.Assert(err, IsNil)
@@ -52,7 +52,7 @@ func (s *systemtestSuite) TestVolsupervisorStopStartSnapshot(c *C) {
 	_, err = s.volcli("volume create policy1/foo")
 	c.Assert(err, IsNil)
 
-	time.Sleep(3 * time.Second)
+	time.Sleep(4 * time.Second)
 
 	out, err = s.vagrant.GetNode("mon0").RunCommandWithOutput("sudo rbd snap ls policy1.foo")
 	c.Assert(err, IsNil)
@@ -64,7 +64,7 @@ func (s *systemtestSuite) TestVolsupervisorRestart(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(s.createVolume("mon0", "policy1", "foo", nil), IsNil)
 
-	time.Sleep(2 * time.Second)
+	time.Sleep(4 * time.Second)
 
 	out, err := s.vagrant.GetNode("mon0").RunCommandWithOutput("sudo rbd snap ls policy1.foo")
 	c.Assert(err, IsNil)
@@ -76,7 +76,7 @@ func (s *systemtestSuite) TestVolsupervisorRestart(c *C) {
 	c.Assert(startVolsupervisor(s.vagrant.GetNode("mon0")), IsNil)
 	c.Assert(waitForVolsupervisor(s.vagrant.GetNode("mon0")), IsNil)
 
-	time.Sleep(2 * time.Second)
+	time.Sleep(4 * time.Second)
 
 	out, err = s.vagrant.GetNode("mon0").RunCommandWithOutput("sudo rbd snap ls policy1.foo")
 	c.Assert(err, IsNil)

--- a/volcli/commands.go
+++ b/volcli/commands.go
@@ -135,6 +135,29 @@ var Commands = []cli.Command{
 				Flags:       VolmasterFlags,
 				Action:      VolumeRemove,
 			},
+			{
+				Name:        "snapshot",
+				Description: "Snapshot management tools",
+				Usage:       "Snapshot management tools",
+				Subcommands: []cli.Command{
+					cli.Command{
+						Name:        "list",
+						ArgsUsage:   "[policy name]/[volume name]",
+						Description: "List snapshots",
+						Usage:       "List snapshots",
+						Flags:       VolmasterFlags,
+						Action:      VolumeSnapshotList,
+					},
+					cli.Command{
+						Name:        "copy",
+						ArgsUsage:   "[policy name]/[volume name] [snapshot name] [new volume name]",
+						Description: "Copies a volume with a given snapshot name to the new volume name. The policy will remain the same, as well as the volume parameters.",
+						Usage:       "Copy a volume snapshot to a new volume",
+						Flags:       VolmasterFlags,
+						Action:      VolumeSnapshotCopy,
+					},
+				},
+			},
 		},
 	},
 	{

--- a/volmaster/daemon.go
+++ b/volmaster/daemon.go
@@ -192,6 +192,11 @@ func (d *DaemonConfig) handleGet(w http.ResponseWriter, r *http.Request) {
 	volName := strings.TrimPrefix(r.URL.Path, "/get/")
 	parts := strings.SplitN(volName, "/", 2)
 
+	if len(parts) != 2 {
+		httpError(w, fmt.Sprintf("Invalid request for path in get: %q", r.URL.Path), nil)
+		return
+	}
+
 	volConfig, err := d.Config.GetVolume(parts[0], parts[1])
 	if err != nil {
 		log.Warn(err)

--- a/volmaster/daemon.go
+++ b/volmaster/daemon.go
@@ -252,26 +252,31 @@ func (d *DaemonConfig) handleCopy(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if volConfig.VolumeName == newVolConfig.VolumeName {
+		httpError(w, fmt.Sprintf("You cannot copy volume %q onto itself.", volConfig.VolumeName), nil)
+		return
+	}
+
 	uc := &config.UseMount{
 		Volume:   volConfig,
-		Reason:   lock.ReasonRemove,
+		Reason:   lock.ReasonCopy,
 		Hostname: host,
 	}
 
 	snapUC := &config.UseSnapshot{
 		Volume: volConfig,
-		Reason: lock.ReasonRemove,
+		Reason: lock.ReasonCopy,
 	}
 
 	newUC := &config.UseMount{
 		Volume:   newVolConfig,
-		Reason:   lock.ReasonRemove,
+		Reason:   lock.ReasonCopy,
 		Hostname: host,
 	}
 
 	newSnapUC := &config.UseSnapshot{
 		Volume: newVolConfig,
-		Reason: lock.ReasonRemove,
+		Reason: lock.ReasonCopy,
 	}
 
 	err = lock.NewDriver(d.Config).ExecuteWithMultiUseLock([]config.UseLocker{newUC, newSnapUC, uc, snapUC}, true, d.Global.Timeout, func(ld *lock.Driver, ucs []config.UseLocker) error {

--- a/volsupervisor/loop.go
+++ b/volsupervisor/loop.go
@@ -60,7 +60,6 @@ func (dc *DaemonConfig) pruneSnapshots(volume string, val *config.VolumeConfig) 
 			log.Infof("Removing snapshot %q for volume %q", list[i], val.VolumeName)
 			if err := driver.RemoveSnapshot(list[i], driverOpts); err != nil {
 				log.Errorf("Removing snapshot %q for volume %q failed: %v", list[i], val.VolumeName, err)
-				return err
 			}
 		}
 

--- a/volsupervisor/loop.go
+++ b/volsupervisor/loop.go
@@ -131,10 +131,10 @@ func (dc *DaemonConfig) loop() {
 				}
 
 				if time.Now().Unix()%int64(freq.Seconds()) == 0 {
-					go func() {
+					go func(volume string, val *config.VolumeConfig) {
 						dc.createSnapshot(volume, val)
 						dc.pruneSnapshots(volume, val)
-					}()
+					}(volume, val)
 				}
 			}
 		}


### PR DESCRIPTION
This implements `volcli volume snapshot` commands:

* `volcli volume snapshot list` will list all snapshots for a given volume
* `volcli volume snapshot copy` will copy a snapshot from volume A into new volume B (under the same policy)

Please take a close look here as a lot has changed.

/cc @jainvipin @mapuri @unclejack 