### PR TITLE
Demo mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ big:
 	BIG=1 vagrant up
 	make build
 
+demo:
+	DEMO=1 make restart
+
 stop:
 	vagrant destroy -f
 	make clean
@@ -78,7 +81,7 @@ docker-push: docker
 
 run:
 	vagrant ssh mon0 -c 'volcli global upload < /testdata/global1.json'
-	@set -e; for i in $$(seq 0 2); do vagrant ssh mon$$i -c 'cd $(GUESTGOPATH) && make run-volplugin run-volmaster'; done
+	@set -e; for i in $$(seq 0 $$(($$(vagrant status | grep -c running) - 2))); do vagrant ssh mon$$i -c 'cd $(GUESTGOPATH) && make run-volplugin run-volmaster'; done
 	vagrant ssh mon0 -c 'cd $(GUESTGOPATH) && make run-volsupervisor'
 
 run-etcd:

--- a/README.md
+++ b/README.md
@@ -35,6 +35,18 @@ be extremely volatile and it is not suggested that you use this in production.
 
 ### Prerequisites:
 
+For a small VM (1 VM, 2048MB ram) for running just the tools and trying it out,
+you can run:
+
+```
+$ make demo
+```
+
+Note that you will still need ansible, virtualbox, and vagrant.
+
+For a more comprehensive version of the system including swarm support across
+several hosts, see below:
+
 On the host, equivalent or greater:
 
 * 12GB of free RAM. Ceph likes RAM.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,6 +9,11 @@ OSX_VMWARE_DIR = "/Applications/VMware Fusion.app/Contents/Library/"
 config_file=File.expand_path(File.join(File.dirname(__FILE__), 'vagrant_variables.yml'))
 settings=YAML.load_file(config_file)
 
+if ENV["DEMO"]
+  settings["vms"] = 1
+  settings["memory"] = 2048
+end
+
 NMONS        = ENV["VMS"] || settings['vms']
 SUBNET       = settings['subnet']
 BOX          = settings['vagrant_box']


### PR DESCRIPTION
This supplies a `make demo` target which spins up only 1 VM with 2048 (from our typical 4096) MB ram.

This should theoretically make it simpler to provision and easier for people to try out.