### PR TITLE
Collins fix

### DIFF
--- a/ansible/roles/contiv_cluster/defaults/main.yml
+++ b/ansible/roles/contiv_cluster/defaults/main.yml
@@ -1,7 +1,8 @@
 ---
 # role variable for the cluster manager service
 
-collins_image: contiv/collins:02_25_2016
+collins_image: contiv/collins
+collins_image_version: "02_25_2016"
 collins_host_port: 9000
 collins_guest_port: 9000
 

--- a/ansible/roles/contiv_cluster/tasks/main.yml
+++ b/ansible/roles/contiv_cluster/tasks/main.yml
@@ -11,10 +11,16 @@
   tags:
     - prebake-for-dev
 
+- name: check for collins image
+  shell: "docker images | grep {{ collins_image }} | grep -q {{ collins_image_version }}"
+  ignore_errors: true
+  register: collins_exists
+
 - name: pull collins container image
-  shell: docker pull {{ collins_image }}
+  shell: "docker pull {{ collins_image }}:{{ collins_image_version }}"
   tags:
     - prebake-for-dev
+  when: not collins_exists|success
 
 - name: start collins
   service: name=collins state=started

--- a/ansible/roles/swarm/tasks/main.yml
+++ b/ansible/roles/swarm/tasks/main.yml
@@ -1,10 +1,19 @@
 ---
 # This role contains tasks for configuring and starting swarm service
+- name: check for swarm image
+  shell: "docker images | grep swarm | grep -q {{ swarm_version }}"
+  ignore_errors: true
+  register: swarm_exists
+
+- name: "swarm exists"
+  debug:
+    var: swarm_exists
 
 - name: download swarm container image
   shell: docker pull swarm:{{ swarm_version }}
   tags:
     - prebake-for-dev
+  when: not swarm_exists|success
 
 - name: copy the swarm start/stop script
   template: src=swarm.j2 dest=/usr/bin/swarm.sh mode=u=rwx,g=rx,o=rx


### PR DESCRIPTION
    collins and swarm are large container images that we save during the build
    process; however, no attempt to determine if the image is already installed is
    made before pulling it, causing an expensive web hit at best and a fresh
    download of a version we don't want at worst.