### PR TITLE
More fixes

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,7 +1,7 @@
 {
 	"ImportPath": "github.com/contiv/volplugin",
 	"GoVersion": "go1.6",
-	"GodepVersion": "v58",
+	"GodepVersion": "v60",
 	"Packages": [
 		"./..."
 	],
@@ -26,11 +26,11 @@
 		},
 		{
 			"ImportPath": "github.com/contiv/errored",
-			"Rev": "23dd1e9452a8e2e2416a5d7ab5cf848ad8af7e16"
+			"Rev": "b0e254c415ecd809cd8fa0af8d3a4349e7044f18"
 		},
 		{
 			"ImportPath": "github.com/contiv/executor",
-			"Rev": "b6a8a0e4ce7d5952fe8e2d58b42389f4c346837e"
+			"Rev": "092266c816a36190e3fce514ad8bb375023f1c81"
 		},
 		{
 			"ImportPath": "github.com/contiv/systemtests-utils",

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -30,7 +30,7 @@
 		},
 		{
 			"ImportPath": "github.com/contiv/executor",
-			"Rev": "092266c816a36190e3fce514ad8bb375023f1c81"
+			"Rev": "38f7b30f73e7d6fc53ed60238f3406d28ad02270"
 		},
 		{
 			"ImportPath": "github.com/contiv/systemtests-utils",

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ docker-push: docker
 
 run:
 	vagrant ssh mon0 -c 'volcli global upload < /testdata/global1.json'
-	@set -e; for i in $$(seq 0 $$(($$(vagrant status | grep -c running) - 2))); do vagrant ssh mon$$i -c 'cd $(GUESTGOPATH) && make run-volplugin run-volmaster'; done
+	@set -e; for i in $$(seq 0 $$(($$(vagrant status | grep -v "not running" | grep -c running) - 1))); do vagrant ssh mon$$i -c 'cd $(GUESTGOPATH) && make run-volplugin run-volmaster'; done
 	vagrant ssh mon0 -c 'cd $(GUESTGOPATH) && make run-volsupervisor'
 
 run-etcd:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -56,7 +56,7 @@ ansible_provision = proc do |ansible|
 
   # In a production deployment, these should be secret
   ansible.extra_vars = {
-    docker_version: "1.10.2",
+    docker_version: "1.10.3",
     swarm_bootstrap_node_name: "mon0",
     docker_device: "/dev/sdb",
     etcd_peers_group: 'volplugin-test',

--- a/ansible/roles/etcd/tasks/main.yml
+++ b/ansible/roles/etcd/tasks/main.yml
@@ -1,17 +1,17 @@
 ---
 # This role contains tasks for configuring and starting etcd service
 
-- name: download etcd v2.1.1
+- name: download etcd v2.3.0
   get_url:
     validate_certs: "{{ validate_certs }}"
-    url: https://github.com/coreos/etcd/releases/download/v2.1.1/etcd-v2.1.1-linux-amd64.tar.gz
-    dest: /tmp/etcd-v2.1.1-linux-amd64.tar.gz
+    url: https://github.com/coreos/etcd/releases/download/v2.3.0/etcd-v2.3.0-linux-amd64.tar.gz
+    dest: /tmp/etcd-v2.3.0-linux-amd64.tar.gz
     force: no
   tags:
     - prebake-for-dev
 
 - name: install etcd
-  shell: creates=/usr/bin/etcd tar vxzf /tmp/etcd-v2.1.1-linux-amd64.tar.gz && mv etcd-v2.1.1-linux-amd64/etcd* /usr/bin
+  shell: creates=/usr/bin/etcd tar vxzf /tmp/etcd-v2.3.0-linux-amd64.tar.gz && mv etcd-v2.3.0-linux-amd64/etcd* /usr/bin
   tags:
     - prebake-for-dev
 

--- a/config/global.go
+++ b/config/global.go
@@ -36,6 +36,7 @@ func NewGlobalConfig() *Global {
 		TTL:       DefaultGlobalTTL,
 		Backend:   ceph.BackendName,
 		MountPath: defaultMountPath,
+		Timeout:   10 * time.Minute,
 	}
 }
 

--- a/config/use_test.go
+++ b/config/use_test.go
@@ -19,15 +19,24 @@ var testUseMounts = map[string]*UseMount{
 		Volume:   testUseVolumes["basic"],
 		Hostname: "hostname",
 	},
+	"basic-newhost": {
+		Volume:   testUseVolumes["basic"],
+		Hostname: "hostname2",
+	},
 	"basic2": {
 		Volume:   testUseVolumes["basic2"],
 		Hostname: "hostname",
+	},
+	"basic2-newhost": {
+		Volume:   testUseVolumes["basic2"],
+		Hostname: "hostname2",
 	},
 }
 
 func (s *configSuite) TestUseCRUD(c *C) {
 	c.Assert(s.tlc.PublishUse(testUseMounts["basic"]), IsNil)
-	c.Assert(s.tlc.PublishUse(testUseMounts["basic"]), NotNil)
+	c.Assert(s.tlc.PublishUse(testUseMounts["basic"]), IsNil)
+	c.Assert(s.tlc.PublishUse(testUseMounts["basic-newhost"]), NotNil)
 	c.Assert(s.tlc.RemoveUse(testUseMounts["basic"], false), IsNil)
 	c.Assert(s.tlc.PublishUse(testUseMounts["basic"]), IsNil)
 
@@ -37,7 +46,7 @@ func (s *configSuite) TestUseCRUD(c *C) {
 	c.Assert(testUseMounts["basic"], DeepEquals, mt)
 
 	c.Assert(s.tlc.PublishUse(testUseMounts["basic2"]), IsNil)
-	c.Assert(s.tlc.PublishUse(testUseMounts["basic2"]), NotNil)
+	c.Assert(s.tlc.PublishUse(testUseMounts["basic2"]), IsNil)
 	c.Assert(s.tlc.RemoveUse(testUseMounts["basic2"], false), IsNil)
 	c.Assert(s.tlc.PublishUse(testUseMounts["basic2"]), IsNil)
 

--- a/lock/client/client.go
+++ b/lock/client/client.go
@@ -107,12 +107,12 @@ func (d *Driver) reportMountEndpoint(endpoint string, ut *config.UseMount) error
 		return errored.Errorf("Could not read response body: %v", err)
 	}
 
-	if resp.StatusCode != 200 {
-		return errored.Errorf("Status was not 200: was %d: %q", resp.StatusCode, strings.TrimSpace(string(content)))
-	}
-
 	if resp.StatusCode == 404 {
 		return errNotFound
+	}
+
+	if resp.StatusCode != 200 {
+		return errored.Errorf("Status was not 200: was %d: %q", resp.StatusCode, strings.TrimSpace(string(content)))
 	}
 
 	return nil

--- a/lock/lock_test.go
+++ b/lock/lock_test.go
@@ -82,7 +82,7 @@ func (s *lockSuite) TestExecuteWithUseLock(c *C) {
 		uc := &config.UseMount{
 			Volume:   vc,
 			Reason:   ReasonCreate,
-			Hostname: fmt.Sprintf("mon%d", i), // doubly ensure we try to write a use lock at this point
+			Hostname: fmt.Sprintf("mon%d", i+1), // doubly ensure we try to write a use lock at this point
 		}
 
 		go func() {
@@ -169,7 +169,7 @@ func (s *lockSuite) TestExecuteWithMultiUseLock(c *C) {
 		}()
 	}
 
-	for i := 0; i < 100; i++ {
+	for i := 0; i < 50; i++ {
 		c.Assert(<-chErr, Equals, ErrPublish)
 	}
 

--- a/storage/backend/ceph/ceph.go
+++ b/storage/backend/ceph/ceph.go
@@ -1,6 +1,8 @@
 package ceph
 
 import (
+	"encoding/json"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -10,6 +12,7 @@ import (
 	"syscall"
 	"time"
 
+	"golang.org/x/net/context"
 	"golang.org/x/sys/unix"
 
 	"github.com/contiv/errored"
@@ -36,6 +39,11 @@ var spaceSplitRegex = regexp.MustCompile(`\s+`)
 //
 type Driver struct {
 	mountpath string
+}
+
+func runWithTimeout(cmd *exec.Cmd, timeout time.Duration) (*executor.ExecResult, error) {
+	ctx, _ := context.WithTimeout(context.Background(), timeout)
+	return executor.New(cmd).Run(ctx)
 }
 
 // NewDriver is a generator for Driver structs. It is used by the storage
@@ -72,27 +80,18 @@ func (c *Driver) InternalNameToVolpluginName(s string) string {
 
 // Create a volume.
 func (c *Driver) Create(do storage.DriverOptions) error {
-	poolName := do.Volume.Params["pool"]
+	cmd := exec.Command("rbd", "create", do.Volume.Name, "--size", strconv.FormatUint(do.Volume.Size, 10), "--pool", do.Volume.Params["pool"])
+	er, err := runWithTimeout(cmd, do.Timeout)
 
-	ok, err := c.poolExists(poolName)
-	if err != nil {
-		return err
-	}
-
-	if !ok {
-		return errored.Errorf("Pool %q does not exist", poolName)
-	}
-
-	cmd := exec.Command("rbd", "create", do.Volume.Name, "--size", strconv.FormatUint(do.Volume.Size, 10), "--pool", poolName)
-	er, err := executor.NewWithTimeout(cmd, do.Timeout).Run()
-	if err != nil {
-		return err
-	}
-
-	if er.ExitStatus == 4352 {
-		return storage.ErrVolumeExist
-	} else if er.ExitStatus != 0 {
-		return errored.Errorf("Creating disk %q: %v", do.Volume.Name, er)
+	if er != nil {
+		if er.ExitStatus == 17 {
+			return storage.ErrVolumeExist
+		} else if er.ExitStatus != 0 {
+			return errored.Errorf("Creating disk %q: %v", do.Volume.Name, er)
+		}
+	} else if err != nil {
+		fmt.Println(err.(*exec.ExitError).ProcessState.Sys().(syscall.WaitStatus))
+		return errored.Errorf("%#v", err)
 	}
 
 	return nil
@@ -120,22 +119,17 @@ func (c *Driver) Destroy(do storage.DriverOptions) error {
 	poolName := do.Volume.Params["pool"]
 
 	cmd := exec.Command("rbd", "snap", "purge", do.Volume.Name, "--pool", poolName)
-	er, err := executor.NewWithTimeout(cmd, do.Timeout).Run()
-	if err != nil {
-		return err
-	}
+	er, _ := runWithTimeout(cmd, do.Timeout)
 	if er.ExitStatus != 0 {
-		return errored.Errorf("Destroying snapshots for disk %q: %v", do.Volume.Name, er)
+		return errored.Errorf("Destroying snapshots for disk %q: %v", do.Volume.Name, er.Stderr)
 	}
 
 	cmd = exec.Command("rbd", "rm", do.Volume.Name, "--pool", poolName)
-	er, err = executor.NewWithTimeout(cmd, do.Timeout).Run()
-	if err != nil {
-		return err
-	}
-
+	er, _ = runWithTimeout(cmd, do.Timeout)
 	if er.ExitStatus != 0 {
-		return errored.Errorf("Destroying disk %q: %v (%v)", do.Volume.Name, er, er.Stderr)
+		er2, _ := executor.NewCapture(exec.Command("rbd", "ls")).Run(context.Background())
+
+		return errored.Errorf("Destroying disk %q: %v (%v) %v", do.Volume.Name, er, er.Stdout, er2.Stdout)
 	}
 
 	return nil
@@ -144,7 +138,9 @@ func (c *Driver) Destroy(do storage.DriverOptions) error {
 // List all volumes.
 func (c *Driver) List(lo storage.ListOptions) ([]storage.Volume, error) {
 	poolName := lo.Params["pool"]
-	er, err := executor.New(exec.Command("rbd", "ls", poolName)).Run()
+
+retry:
+	er, err := executor.NewCapture(exec.Command("rbd", "ls", poolName, "--format", "json")).Run(context.Background())
 	if err != nil {
 		return nil, err
 	}
@@ -153,8 +149,15 @@ func (c *Driver) List(lo storage.ListOptions) ([]storage.Volume, error) {
 		return nil, errored.Errorf("Listing pool %q: %v", poolName, er)
 	}
 
+	textList := []string{}
+
+	if err := json.Unmarshal([]byte(er.Stdout), &textList); err != nil {
+		log.Errorf("Unmarshalling ls for pool %q: %v. Retrying.", poolName, err)
+		time.Sleep(100 * time.Millisecond)
+		goto retry
+	}
+
 	list := []storage.Volume{}
-	textList := strings.Split(er.Stdout, "\n")
 
 	for _, name := range textList {
 		list = append(list, storage.Volume{Name: strings.TrimSpace(name), Params: storage.Params{"pool": poolName}})
@@ -278,7 +281,7 @@ func (c *Driver) Exists(do storage.DriverOptions) (bool, error) {
 func (c *Driver) CreateSnapshot(snapName string, do storage.DriverOptions) error {
 	snapName = strings.Replace(snapName, " ", "-", -1)
 	cmd := exec.Command("rbd", "snap", "create", do.Volume.Name, "--snap", snapName, "--pool", do.Volume.Params["pool"])
-	er, err := executor.NewWithTimeout(cmd, do.Timeout).Run()
+	er, err := runWithTimeout(cmd, do.Timeout)
 	if err != nil {
 		return err
 	}
@@ -293,7 +296,7 @@ func (c *Driver) CreateSnapshot(snapName string, do storage.DriverOptions) error
 // RemoveSnapshot removes a named snapshot for the volume. Any error will be returned.
 func (c *Driver) RemoveSnapshot(snapName string, do storage.DriverOptions) error {
 	cmd := exec.Command("rbd", "snap", "rm", do.Volume.Name, "--snap", snapName, "--pool", do.Volume.Params["pool"])
-	er, err := executor.NewWithTimeout(cmd, do.Timeout).Run()
+	er, err := runWithTimeout(cmd, do.Timeout)
 	if err != nil {
 		return err
 	}
@@ -309,7 +312,8 @@ func (c *Driver) RemoveSnapshot(snapName string, do storage.DriverOptions) error
 // of snapshots to be returned. Any error will be returned.
 func (c *Driver) ListSnapshots(do storage.DriverOptions) ([]string, error) {
 	cmd := exec.Command("rbd", "snap", "ls", do.Volume.Name, "--pool", do.Volume.Params["pool"])
-	er, err := executor.NewWithTimeout(cmd, do.Timeout).Run()
+	ctx, _ := context.WithTimeout(context.Background(), do.Timeout)
+	er, err := executor.NewCapture(cmd).Run(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -348,7 +352,7 @@ func (c *Driver) CopySnapshot(do storage.DriverOptions, snapName, newName string
 	errChan := make(chan error, 1)
 
 	cmd := exec.Command("rbd", "snap", "protect", do.Volume.Name, "--snap", snapName, "--pool", do.Volume.Params["pool"])
-	er, err := executor.NewWithTimeout(cmd, do.Timeout).Run()
+	er, err := runWithTimeout(cmd, do.Timeout)
 
 	if err != nil {
 		errChan <- err
@@ -360,12 +364,12 @@ func (c *Driver) CopySnapshot(do storage.DriverOptions, snapName, newName string
 		case err := <-errChan:
 			log.Warnf("Error received while copying snapshot: %v. Attempting to cleanup.", err)
 			cmd = exec.Command("rbd", "rm", newName, "--pool", do.Volume.Params["pool"])
-			if er, err := executor.NewWithTimeout(cmd, do.Timeout).Run(); err != nil || er.ExitStatus != 0 {
+			if er, err := runWithTimeout(cmd, do.Timeout); err != nil || er.ExitStatus != 0 {
 				log.Errorf("Error encountered removing new volume %q for volume %q, snapshot %q: %v, %v", newName, do.Volume.Name, snapName, err, er.Stderr)
 				return
 			}
 			cmd := exec.Command("rbd", "snap", "unprotect", do.Volume.Name, "--snap", snapName, "--pool", do.Volume.Params["pool"])
-			if er, err := executor.NewWithTimeout(cmd, do.Timeout).Run(); err != nil || er.ExitStatus != 0 {
+			if er, err := runWithTimeout(cmd, do.Timeout); err != nil || er.ExitStatus != 0 {
 				log.Errorf("Error encountered unprotecting new volume %q for volume %q, snapshot %q: %v, %v", newName, do.Volume.Name, snapName, err, er.Stderr)
 				return
 			}
@@ -380,7 +384,7 @@ func (c *Driver) CopySnapshot(do storage.DriverOptions, snapName, newName string
 	}
 
 	cmd = exec.Command("rbd", "clone", do.Volume.Name, newName, "--snap", snapName, "--pool", do.Volume.Params["pool"])
-	er, err = executor.NewWithTimeout(cmd, do.Timeout).Run()
+	er, err = runWithTimeout(cmd, do.Timeout)
 	if err != nil {
 		errChan <- err
 		return err

--- a/storage/backend/ceph/ceph_test.go
+++ b/storage/backend/ceph/ceph_test.go
@@ -82,6 +82,7 @@ func (s *cephSuite) TestMountUnmountVolume(c *C) {
 	driverOpts := storage.DriverOptions{
 		Volume:    volumeSpec,
 		FSOptions: filesystems["ext4"],
+		Timeout:   5 * time.Second,
 	}
 
 	// we don't care if there's an error here, just want to make sure the create
@@ -108,6 +109,7 @@ func (s *cephSuite) TestSnapshots(c *C) {
 	driverOpts := storage.DriverOptions{
 		Volume:    volumeSpec,
 		FSOptions: filesystems["ext4"],
+		Timeout:   5 * time.Second,
 	}
 
 	c.Assert(driver.Create(driverOpts), IsNil)
@@ -134,6 +136,7 @@ func (s *cephSuite) TestRepeatedMountUnmount(c *C) {
 	driverOpts := storage.DriverOptions{
 		Volume:    volumeSpec,
 		FSOptions: filesystems["ext4"],
+		Timeout:   5 * time.Second,
 	}
 
 	// we don't care if there's an error here, just want to make sure the create
@@ -231,6 +234,7 @@ func (s *cephSuite) TestSnapshotClone(c *C) {
 	driverOpts := storage.DriverOptions{
 		Volume:    volumeSpec,
 		FSOptions: filesystems["ext4"],
+		Timeout:   5 * time.Second,
 	}
 
 	c.Assert(driver.Create(driverOpts), IsNil)

--- a/storage/backend/ceph/internals.go
+++ b/storage/backend/ceph/internals.go
@@ -117,6 +117,7 @@ func (c *Driver) showMapped(timeout time.Duration) (rbdMap, error) {
 		if err != nil || er.ExitStatus == 3072 {
 			log.Warnf("Could not show mapped volumes. Retrying")
 			time.Sleep(100 * time.Millisecond)
+			continue
 		} else {
 			break
 		}

--- a/storage/backend/ceph/util.go
+++ b/storage/backend/ceph/util.go
@@ -2,35 +2,10 @@ package ceph
 
 import (
 	"fmt"
-	"os/exec"
 	"path/filepath"
-	"strings"
 
-	"github.com/contiv/errored"
-	"github.com/contiv/executor"
 	"github.com/contiv/volplugin/storage"
 )
-
-func (c *Driver) poolExists(poolName string) (bool, error) {
-	er, err := executor.New(exec.Command("ceph", "osd", "pool", "ls")).Run()
-	if err != nil {
-		return false, errored.Errorf("Problem listing pools: %v", err)
-	}
-
-	if er.ExitStatus != 0 {
-		return false, errored.Errorf("Problem listing pools: %v", er)
-	}
-
-	lines := strings.Split(er.Stdout, "\n")
-	for _, line := range lines {
-		line = strings.TrimSpace(line)
-		if line == poolName {
-			return true, nil
-		}
-	}
-
-	return false, nil
-}
 
 // MountPath returns the path of a mount for a pool/volume.
 func (c *Driver) MountPath(do storage.DriverOptions) string {

--- a/systemtests/battery_test.go
+++ b/systemtests/battery_test.go
@@ -2,9 +2,9 @@ package systemtests
 
 import (
 	"fmt"
-	"os"
 	"strings"
 	"sync"
+	"time"
 
 	. "gopkg.in/check.v1"
 
@@ -14,7 +14,7 @@ import (
 
 func (s *systemtestSuite) TestBatteryMultiMountSameHost(c *C) {
 	c.Skip("Can't be run until docker fixes this bug")
-	count := 25
+	count := 15
 	errChan := make(chan error, count)
 
 	c.Assert(s.createVolume("mon0", "policy1", "test", nil), IsNil)
@@ -28,76 +28,6 @@ func (s *systemtestSuite) TestBatteryMultiMountSameHost(c *C) {
 		}()
 	}
 
-	for x := 0; x < count; x++ {
-		c.Assert(<-errChan, NotNil)
-	}
-}
-func (s *systemtestSuite) TestBatteryParallelMount(c *C) {
-	nodes := s.vagrant.GetNodes()
-	count := 10
-
-	if os.Getenv("BIG") != "" {
-		count = 50
-	}
-
-	outwg := sync.WaitGroup{}
-	for x := 0; x < count; x++ {
-		outwg.Add(1)
-		go func(nodes []vagrantssh.TestbedNode, x int) {
-			defer outwg.Done()
-			wg := sync.WaitGroup{}
-			errChan := make(chan error, len(nodes))
-
-			for _, node := range nodes {
-				c.Assert(s.createVolume(node.GetName(), "policy1", fmt.Sprintf("test%d", x), nil), IsNil)
-			}
-
-			contID := ""
-			var contNode *vagrantssh.TestbedNode
-
-			for _, node := range nodes {
-				wg.Add(1)
-				go func(node vagrantssh.TestbedNode, x int) {
-					log.Infof("Running alpine container for %d on %q", x, node.GetName())
-
-					if out, err := node.RunCommandWithOutput(fmt.Sprintf("docker run -itd -v policy1/test%d:/mnt alpine sleep 10m", x)); err != nil {
-						errChan <- err
-					} else {
-						contID = strings.TrimSpace(out)
-						contNode = &node
-					}
-
-					wg.Done()
-				}(node, x)
-			}
-
-			wg.Wait()
-
-			var errs int
-
-			for i := 0; i < len(nodes); i++ {
-				select {
-				case <-errChan:
-					errs++
-				default:
-				}
-			}
-			c.Assert(errs, Equals, len(nodes)-1)
-			log.Infof("Removing containers for %d: %s", x, contID)
-			out, err := (*contNode).RunCommandWithOutput(fmt.Sprintf("docker rm -f %s", contID))
-			if err != nil {
-				log.Error(out)
-			}
-			c.Assert(err, IsNil)
-		}(nodes, x)
-	}
-
-	outwg.Wait()
-	errChan := make(chan error, count)
-	for x := 0; x < count; x++ {
-		go func(x int) { errChan <- s.purgeVolume("mon0", "policy1", fmt.Sprintf("test%d", x), true) }(x)
-	}
-
 	var realErr error
 
 	for x := 0; x < count; x++ {
@@ -108,70 +38,171 @@ func (s *systemtestSuite) TestBatteryParallelMount(c *C) {
 	}
 
 	c.Assert(realErr, IsNil)
+}
+func (s *systemtestSuite) TestBatteryParallelMount(c *C) {
+	nodes := s.vagrant.GetNodes()
+	outerCount := 5
+	count := 15
+
+	for outer := 0; outer < outerCount; outer++ {
+		syncChan := make(chan struct{}, len(nodes)*count)
+		errChan := make(chan error, len(nodes)*count)  // two potential errors per goroutine
+		outChan := make(chan string, len(nodes)*count) // diagnostics
+
+		for x := 0; x < count; x++ {
+			go func(nodes []vagrantssh.TestbedNode, x int) {
+				for _, node := range nodes {
+					c.Assert(s.createVolume(node.GetName(), "policy1", fmt.Sprintf("test%d", x), nil), IsNil)
+				}
+
+				contID := ""
+				var contNode *vagrantssh.TestbedNode
+				containerSync := make(chan struct{}, len(nodes))
+
+				for _, node := range nodes {
+					go func(node vagrantssh.TestbedNode, x int) {
+						defer func() { syncChan <- struct{}{} }()
+						defer func() { containerSync <- struct{}{} }()
+						log.Infof("Running alpine container for %d on %q", x, node.GetName())
+
+						if out, err := node.RunCommandWithOutput(fmt.Sprintf("docker run -itd -v policy1/test%d:/mnt alpine sleep 10m", x)); err != nil {
+							outChan <- out
+							errChan <- err
+						} else {
+							contID = strings.TrimSpace(out)
+							contNode = &node
+							errChan <- nil
+						}
+					}(node, x)
+				}
+
+				for i := 0; i < len(nodes); i++ {
+					<-containerSync
+				}
+
+				c.Assert(contNode, NotNil)
+
+				log.Infof("Removing containers for %d (host %q): %s", x, (*contNode).GetName(), contID)
+				out, err := (*contNode).RunCommandWithOutput(fmt.Sprintf("docker rm -f %s", contID))
+				if err != nil {
+					log.Error(out)
+				}
+				c.Assert(err, IsNil)
+			}(nodes, x)
+		}
+
+		for i := 0; i < len(nodes)*count; i++ {
+			<-syncChan
+		}
+
+		var errs int
+
+		for i := 0; i < len(nodes)*count; i++ {
+			err := <-errChan
+			if err != nil {
+				errs++
+			}
+		}
+
+		if errs != count*(len(nodes)-1) {
+			for i := 0; i < len(nodes)*count; i++ {
+				select {
+				case out := <-outChan:
+					log.Error(out)
+				default:
+				}
+			}
+			c.Fail()
+		}
+
+		purgeChan := make(chan error, count)
+		for x := 0; x < count; x++ {
+			go func(x int) { purgeChan <- s.purgeVolume("mon0", "policy1", fmt.Sprintf("test%d", x), true) }(x)
+		}
+
+		errs = 0
+
+		for x := 0; x < count; x++ {
+			err := <-purgeChan
+			if err != nil {
+				log.Error(err)
+				errs++
+			}
+		}
+
+		c.Assert(errs, Equals, 0)
+		// XXX docker seems to ignore the new create if it happens too quickly. File a
+		// bug for this.
+		c.Assert(s.restartDocker(), IsNil)
+		c.Assert(s.clearContainers(), IsNil)
+		time.Sleep(1 * time.Second)
+	}
 }
 
 func (s *systemtestSuite) TestBatteryParallelCreate(c *C) {
 	nodes := s.vagrant.GetNodes()
 	outwg := sync.WaitGroup{}
-	count := 10
+	count := 15
 
-	if os.Getenv("BIG") != "" {
-		count = 50
-	}
+	for outer := 0; outer < 5; outer++ {
+		for x := 0; x < count; x++ {
+			outwg.Add(1)
+			go func(nodes []vagrantssh.TestbedNode, x int) {
+				defer outwg.Done()
+				wg := sync.WaitGroup{}
+				errChan := make(chan error, len(nodes))
 
-	for x := 0; x < count; x++ {
-		outwg.Add(1)
-		go func(nodes []vagrantssh.TestbedNode, x int) {
-			defer outwg.Done()
-			wg := sync.WaitGroup{}
-			errChan := make(chan error, len(nodes))
+				for _, node := range nodes {
+					wg.Add(1)
+					go func(node vagrantssh.TestbedNode, x int) {
+						defer wg.Done()
+						log.Infof("Creating image policy1/test%d on %q", x, node.GetName())
 
-			for _, node := range nodes {
-				wg.Add(1)
-				go func(node vagrantssh.TestbedNode, x int) {
-					defer wg.Done()
-					log.Infof("Creating image policy1/test%d on %q", x, node.GetName())
-
-					if out, err := node.RunCommandWithOutput(fmt.Sprintf("volcli volume create policy1/test%d", x)); err != nil {
-						log.Error(out)
-						log.Error(err)
-						errChan <- err
-					}
-				}(node, x)
-			}
-
-			wg.Wait()
-
-			var errs int
-
-			for i := 0; i < len(nodes); i++ {
-				select {
-				case err := <-errChan:
-					log.Errorf("Processing %d: %v", x, err)
-					errs++
-				default:
+						if out, err := node.RunCommandWithOutput(fmt.Sprintf("volcli volume create policy1/test%d", x)); err != nil {
+							log.Error(out)
+							log.Error(err)
+							errChan <- err
+						}
+					}(node, x)
 				}
-			}
 
-			c.Assert(errs, Equals, 0)
-		}(nodes, x)
-	}
+				wg.Wait()
 
-	outwg.Wait()
+				var errs int
 
-	errChan := make(chan error, count)
-	for x := 0; x < count; x++ {
-		go func(x int) { errChan <- s.purgeVolume("mon0", "policy1", fmt.Sprintf("test%d", x), true) }(x)
-	}
+				for i := 0; i < len(nodes); i++ {
+					select {
+					case err := <-errChan:
+						log.Errorf("Processing %d: %v", x, err)
+						errs++
+					default:
+					}
+				}
 
-	var realErr error
-
-	for x := 0; x < count; x++ {
-		err := <-errChan
-		if err != nil {
-			realErr = err
+				c.Assert(errs, Equals, 0)
+			}(nodes, x)
 		}
-	}
 
-	c.Assert(realErr, IsNil)
+		outwg.Wait()
+
+		errChan := make(chan error, count)
+		for x := 0; x < count; x++ {
+			go func(x int) { errChan <- s.purgeVolume("mon0", "policy1", fmt.Sprintf("test%d", x), true) }(x)
+		}
+
+		var realErr error
+
+		for x := 0; x < count; x++ {
+			err := <-errChan
+			if err != nil {
+				realErr = err
+			}
+		}
+
+		c.Assert(realErr, IsNil)
+
+		out, err := s.mon0cmd("sudo rbd ls")
+		c.Assert(err, IsNil)
+		c.Assert(out, Equals, "")
+	}
 }

--- a/systemtests/init_test.go
+++ b/systemtests/init_test.go
@@ -1,8 +1,8 @@
 package systemtests
 
 import (
+	"fmt"
 	"os"
-	"strings"
 	. "testing"
 
 	. "gopkg.in/check.v1"
@@ -29,41 +29,20 @@ func (s *systemtestSuite) SetUpTest(c *C) {
 	c.Assert(s.rebootstrap(), IsNil)
 }
 
-func (s *systemtestSuite) TearDownTest(c *C) {
-	if os.Getenv("CONTIV_SOE") != "" {
-		log.Infof("SOE set. Terminating immediately")
-		os.Exit(1)
-	}
-}
-
-func (s *systemtestSuite) TearDownSuite(c *C) {
-	if os.Getenv("NO_TEARDOWN") != "" || os.Getenv("CONTIV_SOE") != "" {
-		os.Exit(0)
-	}
-
-	log.Infof("Tearing down system test facilities")
-
-	s.clearContainers()
-	s.clearVolumes()
-	s.restartDocker()
-
-	c.Assert(s.vagrant.IterateNodes(stopVolplugin), IsNil)
-	c.Assert(stopVolmaster(s.vagrant.GetNode("mon0")), IsNil)
-}
-
 func (s *systemtestSuite) SetUpSuite(c *C) {
 	log.Infof("Bootstrapping system tests")
-
 	s.vagrant = vagrantssh.Vagrant{}
 	c.Assert(s.vagrant.Setup(false, "", 3), IsNil)
 
-	err := s.clearContainers()
-	if err != nil && !strings.Contains(err.Error(), "Process exited with: 123") {
-		c.Fatal(err)
+	for _, service := range []string{"volplugin", "volmaster", "volsupervisor"} {
+		for _, node := range s.vagrant.GetNodes() {
+			node.RunCommand(fmt.Sprintf("sudo systemctl stop %s", service))
+			node.RunCommand(fmt.Sprintf("sudo systemctl disable %s", service))
+		}
 	}
 
+	c.Assert(s.restartDocker(), IsNil)
 	c.Assert(s.pullDebian(), IsNil)
-	c.Assert(s.rebootstrap(), IsNil)
 
 	out, err := s.uploadIntent("policy1", "policy1")
 	c.Assert(err, IsNil, Commentf("output: %s", out))

--- a/systemtests/testdata/global1.json
+++ b/systemtests/testdata/global1.json
@@ -1,5 +1,5 @@
 {
-  "TTL": 5,
+  "TTL": 30,
   "Debug": true,
   "Timeout": 10
 }

--- a/systemtests/testdata/global2.json
+++ b/systemtests/testdata/global2.json
@@ -1,5 +1,5 @@
 {
   "Debug": false,
-  "TTL": 10,
+  "TTL": 30,
   "Timeout": 30
 }

--- a/systemtests/testdata/mountpath_global.json
+++ b/systemtests/testdata/mountpath_global.json
@@ -1,6 +1,6 @@
 {
   "TTL": 5,
   "Debug": true,
-  "Timeout": 10
+  "Timeout": 10,
   "MountPath": "/mnt/test"
 }

--- a/systemtests/testdata/mountpath_global.json
+++ b/systemtests/testdata/mountpath_global.json
@@ -1,1 +1,6 @@
-{"MountPath": "/mnt/test"}
+{
+  "TTL": 5,
+  "Debug": true,
+  "Timeout": 10
+  "MountPath": "/mnt/test"
+}

--- a/systemtests/volmaster_test.go
+++ b/systemtests/volmaster_test.go
@@ -25,7 +25,7 @@ func (s *systemtestSuite) TestVolmasterFailedFormat(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(s.createVolume("mon0", "policy2", "testfalse", map[string]string{"filesystem": "falsefs"}), NotNil)
 	_, err = s.volcli("volume remove policy2/testfalse")
-	c.Assert(err, IsNil)
+	c.Assert(err, NotNil)
 }
 
 func (s *systemtestSuite) TestVolmasterGlobalConfigUpdate(c *C) {
@@ -85,7 +85,7 @@ func (s *systemtestSuite) TestVolmasterMultiRemove(c *C) {
 			errs++
 		}
 		if out != "" {
-			c.Assert(strings.Contains(out, `Volume "policy1/test" no longer exists`), Equals, true)
+			c.Assert(strings.Contains(out, `Removing volume policy1/test Volume policy1/test no longer exists`), Equals, true)
 		}
 	}
 

--- a/systemtests/volplugin_test.go
+++ b/systemtests/volplugin_test.go
@@ -52,15 +52,16 @@ func (s *systemtestSuite) TestVolpluginCrashRestart(c *C) {
 	c.Assert(s.createVolume("mon0", "policy1", "test", nil), IsNil)
 	c.Assert(s.vagrant.GetNode("mon0").RunCommand("docker run -itd -v policy1/test:/mnt alpine sleep 10m"), IsNil)
 	c.Assert(stopVolplugin(s.vagrant.GetNode("mon0")), IsNil)
-	time.Sleep(10 * time.Second) // this is based on a 5s ttl set at volmaster/volplugin startup
+	time.Sleep(45 * time.Second) // this is based on a 5s ttl set at volmaster/volplugin startup
 	c.Assert(startVolplugin(s.vagrant.GetNode("mon0")), IsNil)
-	time.Sleep(1 * time.Second)
+	c.Assert(waitForVolplugin(s.vagrant.GetNode("mon0")), IsNil)
 	c.Assert(s.createVolume("mon1", "policy1", "test", nil), IsNil)
 	c.Assert(s.vagrant.GetNode("mon1").RunCommand("docker run -itd -v policy1/test:/mnt alpine sleep 10m"), NotNil)
 
 	c.Assert(stopVolplugin(s.vagrant.GetNode("mon0")), IsNil)
 	c.Assert(startVolplugin(s.vagrant.GetNode("mon0")), IsNil)
-	time.Sleep(10 * time.Second)
+	c.Assert(waitForVolplugin(s.vagrant.GetNode("mon0")), IsNil)
+	time.Sleep(45 * time.Second)
 	c.Assert(s.createVolume("mon1", "policy1", "test", nil), IsNil)
 	c.Assert(s.vagrant.GetNode("mon1").RunCommand("docker run -itd -v policy1/test:/mnt alpine sleep 10m"), NotNil)
 

--- a/vagrant_variables.yml
+++ b/vagrant_variables.yml
@@ -7,7 +7,7 @@ vms: 3
 subnet: 192.168.24
 
 # MEMORY
-memory: 4096
+memory: 8192
 
 # VAGRANT BOX
 # Fedora: https://download.fedoraproject.org/pub/fedora/linux/releases/22/Cloud/x86_64/Images/Fedora-Cloud-Base-Vagrant-22-20150521.x86_64.vagrant-virtualbox.box

--- a/vendor/github.com/contiv/errored/LICENSE
+++ b/vendor/github.com/contiv/errored/LICENSE
@@ -1,0 +1,13 @@
+Copyright 2016 Cisco Systems Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/vendor/github.com/contiv/errored/README.md
+++ b/vendor/github.com/contiv/errored/README.md
@@ -1,0 +1,44 @@
+[![ReportCard][ReportCard-Image]][ReportCard-URL] [![Build][Build-Status-Image]][Build-Status-URL] [![GoDoc][GoDoc-Image]][GoDoc-URL]
+
+# Errored: flexible error messages for golang
+
+Package errored implements specialized errors for golang that come with:
+
+* Debug and Trace modes
+  * Debug emits the location the error was created, Trace emits the whole stack.
+* Error combination
+  * Make two errors into one; carries the trace information for both errors with it!
+
+Use it just like `fmt`:
+
+```go
+package main
+
+import "github.com/contiv/errored"
+
+func main() {
+	err := errored.Errorf("a message")
+	err.SetDebug(true)
+	err.Error() // => "a message [ <file> <line> <line number> ]"
+	err2 := errored.Errorf("another message")
+	combined := err.Combine(err2)
+	combined.SetTrace(true)
+	combined.Error() // => "a message: another message" + two stack traces
+}
+```
+
+## Authors:
+
+* Madhav Puri
+* Erik Hollensbe
+
+## Sponsorship
+
+Project Contiv is sponsored by Cisco Systems, Inc.
+
+[ReportCard-URL]: https://goreportcard.com/report/github.com/contiv/errored
+[ReportCard-Image]: http://goreportcard.com/badge/contiv/errored
+[Build-Status-URL]: http://travis-ci.org/contiv/errored
+[Build-Status-Image]: https://travis-ci.org/contiv/errored.svg?branch=master
+[GoDoc-URL]: https://godoc.org/github.com/contiv/errored
+[GoDoc-Image]: https://godoc.org/github.com/contiv/errored?status.svg

--- a/vendor/github.com/contiv/executor/.gitignore
+++ b/vendor/github.com/contiv/executor/.gitignore
@@ -1,2 +1,1 @@
-test
 cover.out

--- a/vendor/github.com/contiv/executor/README.md
+++ b/vendor/github.com/contiv/executor/README.md
@@ -1,0 +1,47 @@
+[![ReportCard][ReportCard-Image]][ReportCard-URL] [![Build][Build-Status-Image]][Build-Status-URL] [![GoDoc][GoDoc-Image]][GoDoc-URL]
+
+## Executor: flexible, high-level exec.Cmd for golang
+
+Package executor implements a high level execution context with monitoring,
+control, and logging features. It is made for services which execute lots of
+small programs and need to carefully control i/o and processes.
+
+Executor can:
+
+  * Terminate on signal or after a timeout via /x/net/context
+  * Output a message on an interval if the program is still running.
+  * Capture split-stream stdio, and make it easier to get at io pipes.
+
+Example:
+
+```go
+  e := executor.New(exec.Command("/bin/sh", "echo hello"))
+  e.Start() // start
+  fmt.Println(e.PID()) // get the pid
+  fmt.Printf("%v\n", e) // pretty string output
+  er, err := e.Wait(context.Background()) // wait for termination
+  fmt.Println(er.ExitStatus) // => 0
+  
+  // lets capture some io, and timeout after a while
+  e := executor.NewCapture(exec.Command("/bin/sh", "yes"))
+  e.Start()
+  ctx, _ := context.WithTimeout(context.Background(), 10 * time.Second)
+  er, err := e.Wait(ctx) // wait for only 10 seconds
+  fmt.Println(err == context.DeadlineExceeded)
+  fmt.Println(er.Stdout) // yes\nyes\nyes\n...
+```
+
+## Authors:
+
+* Erik Hollensbe
+
+## Sponsorship
+
+Project Contiv is sponsored by Cisco Systems, Inc.
+
+[ReportCard-URL]: https://goreportcard.com/report/github.com/contiv/executor
+[ReportCard-Image]: http://goreportcard.com/badge/contiv/executor
+[Build-Status-URL]: http://travis-ci.org/contiv/executor
+[Build-Status-Image]: https://travis-ci.org/contiv/executor.svg?branch=master
+[GoDoc-URL]: https://godoc.org/github.com/contiv/executor
+[GoDoc-Image]: https://godoc.org/github.com/contiv/executor?status.svg

--- a/vendor/github.com/contiv/executor/executor.go
+++ b/vendor/github.com/contiv/executor/executor.go
@@ -233,7 +233,8 @@ func (e *Executor) Wait(ctx context.Context) (*ExecResult, error) {
 }
 
 // Run calls Start(), then Wait(), and returns an ExecResult and error (if
-// any). If an error is returned, ExecResult will be nil.
+// any). The error may be of many types including *exec.ExitError and
+// context.Canceled, context.DeadlineExceeded.
 func (e *Executor) Run(ctx context.Context) (*ExecResult, error) {
 	if err := e.Start(); err != nil {
 		return nil, err

--- a/vendor/github.com/contiv/executor/executor.go
+++ b/vendor/github.com/contiv/executor/executor.go
@@ -1,16 +1,41 @@
-// Package executor implements a high level execution context with monitoring and
-// logging features.
+// Package executor implements a high level execution context with monitoring,
+// control, and logging features. It is made for services which execute lots of
+// small programs and need to carefully control i/o and processes.
 //
-// Please see Executor for more information.
+// Executor can:
+//
+//   * Terminate on signal or after a timeout via /x/net/context
+//   * Output a message on an interval if the program is still running.
+//   * Capture split-stream stdio, and make it easier to get at io pipes.
+//
+// Example:
+//
+//		e := executor.New(exec.Command("/bin/sh", "echo hello"))
+//		e.Start() // start
+//		fmt.Println(e.PID()) // get the pid
+//		fmt.Printf("%v\n", e) // pretty string output
+//		er, err := e.Wait(context.Background()) // wait for termination
+//		fmt.Println(er.ExitStatus) // => 0
+//
+//		// lets capture some io, and timeout after a while
+//		e := executor.NewCapture(exec.Command("/bin/sh", "yes"))
+// 		e.Start()
+//		ctx, _ := context.WithTimeout(context.Background(), 10 * time.Second)
+//		er, err := e.Wait(ctx) // wait for only 10 seconds
+//		fmt.Println(err == context.DeadlineExceeded)
+//		fmt.Println(er.Stdout) // yes\nyes\nyes\n...
+//
 package executor
 
 import (
+	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os/exec"
 	"syscall"
 	"time"
+
+	"golang.org/x/net/context"
 
 	"github.com/Sirupsen/logrus"
 )
@@ -21,7 +46,7 @@ import (
 type ExecResult struct {
 	Stdout     string
 	Stderr     string
-	ExitStatus uint32
+	ExitStatus int
 	Runtime    time.Duration
 
 	executor *Executor
@@ -30,7 +55,7 @@ type ExecResult struct {
 // Executor is the context used to execute a process. The runtime state is kept
 // here. Please see the struct fields for more information.
 //
-// New() is the appropriate way to initialize this type.
+// New(), NewIO(), or NewCapture() are the appropriate ways to initialize this type.
 //
 // No attempt is made to manage concurrent requests to this struct after
 // the program has started.
@@ -38,60 +63,61 @@ type Executor struct {
 	// The interval at which we will log that we are still running.
 	LogInterval time.Duration
 
-	// If a true value is passed into this channel, the process will be forcefully
-	// terminated. A false value terminates only the supervising goroutines, and
-	// is used by Wait().
-	TerminateChan chan bool
-
 	// The function used for logging. Expects a format-style string and trailing args.
 	LogFunc func(string, ...interface{})
 
 	// The stdin as passed to the process.
 	Stdin io.Reader
 
-	timeout time.Duration
-
-	command          *exec.Cmd
-	stdout           io.ReadCloser
-	stderr           io.ReadCloser
-	startTime        time.Time
-	terminateLogger  chan struct{}
-	timeoutTerminate chan struct{}
+	io              bool
+	capture         bool
+	command         *exec.Cmd
+	stdout          io.ReadCloser
+	stderr          io.ReadCloser
+	stdoutBuf       *bytes.Buffer
+	stderrBuf       *bytes.Buffer
+	startTime       time.Time
+	terminateLogger chan struct{}
 }
 
 // New creates a new executor from an *exec.Cmd. You may modify the values
-// before calling Start(). See Executor for more information.
+// before calling Start(). See Executor for more information. Use NewCapture if
+// you want executor to capture output for you.
 func New(cmd *exec.Cmd) *Executor {
-	return &Executor{
-		LogInterval:      1 * time.Minute,
-		TerminateChan:    make(chan bool, 1),
-		LogFunc:          logrus.Debugf,
-		command:          cmd,
-		stdout:           nil,
-		stderr:           nil,
-		terminateLogger:  make(chan struct{}, 1),
-		timeoutTerminate: make(chan struct{}, 1),
-	}
+	return newExecutor(false, false, cmd)
 }
 
-// NewWithTimeout creates a new executor from an *exec.Cmd and a timeout.
-// You may modify the values before calling Start(). See Executor for
-// more information.
-func NewWithTimeout(cmd *exec.Cmd, timeout time.Duration) *Executor {
-	exec := New(cmd)
-	exec.SetTimeout(timeout)
-	return exec
+// NewIO creates a new executor but allows the Out() and Err() methods to provide
+// a io.ReadCloser as a pipe from the stdout and error respectively. If you
+// wish to read large volumes of output this is the way to go.
+func NewIO(cmd *exec.Cmd) *Executor {
+	return newExecutor(true, false, cmd)
+}
+
+// NewCapture creates an instance of executor suitable for capturing output.
+// The Wait() call will automatically yield the stdout and stderr of the
+// program. NOTE: this can potentially use unbounded amounts of ram; use carefully.
+func NewCapture(cmd *exec.Cmd) *Executor {
+	return newExecutor(true, true, cmd)
+}
+
+func newExecutor(useIO, useCapture bool, cmd *exec.Cmd) *Executor {
+	return &Executor{
+		io:              useIO,
+		capture:         useCapture,
+		LogInterval:     1 * time.Minute,
+		LogFunc:         logrus.Debugf,
+		command:         cmd,
+		stdout:          nil,
+		stderr:          nil,
+		stdoutBuf:       nil,
+		stderrBuf:       nil,
+		terminateLogger: make(chan struct{}),
+	}
 }
 
 func (e *Executor) String() string {
 	return fmt.Sprintf("%v (%v) (pid: %v)", e.command.Args, e.command.Path, e.PID())
-}
-
-// SetTimeout sets the process timeout. If a non-zero timeout is provided, it
-// will forcefully terminate the process after it is reached. It must be called
-// before Start().
-func (e *Executor) SetTimeout(t time.Duration) {
-	e.timeout = t
 }
 
 // Start starts the command in the Executor context. It returns any error upon
@@ -104,25 +130,29 @@ func (e *Executor) Start() error {
 
 	var err error
 
-	e.stdout, err = e.command.StdoutPipe()
-	if err != nil {
-		return err
-	}
+	if e.io {
+		e.stdout, err = e.command.StdoutPipe()
+		if err != nil {
+			return err
+		}
 
-	e.stderr, err = e.command.StderrPipe()
-	if err != nil {
-		return err
+		e.stderr, err = e.command.StderrPipe()
+		if err != nil {
+			return err
+		}
+
+		if e.capture {
+			e.stdoutBuf = new(bytes.Buffer)
+			go io.Copy(e.stdoutBuf, e.stdout)
+
+			e.stderrBuf = new(bytes.Buffer)
+			go io.Copy(e.stderrBuf, e.stderr)
+		}
 	}
 
 	if err := e.command.Start(); err != nil {
 		e.LogFunc("Error executing %v: %v", e, err)
 		return err
-	}
-
-	go e.waitForStop()
-
-	if e.timeout != 0 {
-		go e.terminateTimeout()
 	}
 
 	go e.logInterval()
@@ -134,30 +164,6 @@ func (e *Executor) Start() error {
 // see ExecResult.Runtime.
 func (e *Executor) TimeRunning() time.Duration {
 	return time.Now().Sub(e.startTime)
-}
-
-func (e *Executor) terminateTimeout() {
-	select {
-	case <-e.timeoutTerminate:
-	case <-time.After(e.timeout):
-		e.TerminateChan <- true
-	}
-}
-
-func (e *Executor) waitForStop() {
-	terminate := <-e.TerminateChan
-
-	if terminate {
-		if e.command.Process == nil {
-			e.LogFunc("Could not terminate non-running command %v", e)
-		} else {
-			e.LogFunc("Command %v terminated due to timeout. It may not have finished!", e)
-			e.command.Process.Kill()
-		}
-	}
-
-	e.terminateLogger <- struct{}{}
-	return
 }
 
 func (e *Executor) logInterval() {
@@ -181,60 +187,61 @@ func (e *Executor) PID() uint32 {
 	return 0
 }
 
-// Wait waits for the process and return an ExecResult. The program died due to
-// another problem without returning an exit status, a nil result is yielded.B
+// Wait waits for the process and return an ExecResult and any error it
+// encountered along the way. While the error may or may not be nil, the
+// ExecResult will always exist with as much information as we could get.
 //
-// If the ExecResult is returned, error will be nil, regardless of the
-// ExitError returned by (*exec.Cmd).Wait(). If an error is returned it should
-// be handled appropriately.
-func (e *Executor) Wait() (*ExecResult, error) {
-	stdout, err := ioutil.ReadAll(e.stdout)
-	if err != nil {
-		return nil, err
-	}
+// Context is from https://godoc.org/golang.org/x/net/context (see
+// https://blog.golang.org/context for usage). You can use it to set timeouts
+// and cancel executions.
+func (e *Executor) Wait(ctx context.Context) (*ExecResult, error) {
+	defer close(e.terminateLogger)
 
-	stderr, err := ioutil.ReadAll(e.stderr)
-	if err != nil {
-		return nil, err
-	}
+	var err error
+	errChan := make(chan error, 1)
 
-	res := &ExecResult{
-		executor: e,
-		Stdout:   string(stdout),
-		Stderr:   string(stderr),
-	}
+	go func() { errChan <- e.command.Wait() }()
 
-	err = e.command.Wait()
-
-	e.TerminateChan <- false // signal goroutines to terminate gracefully
-
-	if e.timeout != 0 {
-		e.timeoutTerminate <- struct{}{}
-	}
-
-	if err != nil {
-		// if not exiterror, do not yield an execresult
-		if exit, ok := err.(*exec.ExitError); ok {
-			res.ExitStatus = uint32(exit.Sys().(syscall.WaitStatus))
+	select {
+	case <-ctx.Done():
+		if e.command.Process == nil {
+			e.LogFunc("Could not terminate non-running command %v", e)
 		} else {
-			return nil, err
+			e.LogFunc("Command %v terminated due to timeout or cancellation. It may not have finished!", e)
+			e.command.Process.Kill()
+		}
+		err = ctx.Err()
+	case err = <-errChan:
+	}
+
+	res := &ExecResult{executor: e}
+
+	if err != nil {
+		if exit, ok := err.(*exec.ExitError); ok {
+			res.ExitStatus = int(exit.ProcessState.Sys().(syscall.WaitStatus) / 256)
 		}
 	}
 
+	if e.capture {
+		res.Stdout = string(e.stdoutBuf.Bytes())
+		res.Stderr = string(e.stderrBuf.Bytes())
+	}
+
 	res.Runtime = e.TimeRunning()
-	return res, nil
+
+	return res, err
 }
 
 // Run calls Start(), then Wait(), and returns an ExecResult and error (if
 // any). If an error is returned, ExecResult will be nil.
-func (e *Executor) Run() (*ExecResult, error) {
+func (e *Executor) Run(ctx context.Context) (*ExecResult, error) {
 	if err := e.Start(); err != nil {
 		return nil, err
 	}
 
-	er, err := e.Wait()
+	er, err := e.Wait(ctx)
 	if err != nil {
-		return nil, err
+		return er, err
 	}
 
 	return er, nil

--- a/volcli/commands.go
+++ b/volcli/commands.go
@@ -140,7 +140,7 @@ var Commands = []cli.Command{
 				Description: "Snapshot management tools",
 				Usage:       "Snapshot management tools",
 				Subcommands: []cli.Command{
-					cli.Command{
+					{
 						Name:        "list",
 						ArgsUsage:   "[policy name]/[volume name]",
 						Description: "List snapshots",
@@ -148,7 +148,7 @@ var Commands = []cli.Command{
 						Flags:       VolmasterFlags,
 						Action:      VolumeSnapshotList,
 					},
-					cli.Command{
+					{
 						Name:        "copy",
 						ArgsUsage:   "[policy name]/[volume name] [snapshot name] [new volume name]",
 						Description: "Copies a volume with a given snapshot name to the new volume name. The policy will remain the same, as well as the volume parameters.",

--- a/volcli/volcli.go
+++ b/volcli/volcli.go
@@ -305,7 +305,7 @@ func volumeCreate(ctx *cli.Context) (bool, error) {
 
 	resp, err := http.Post(fmt.Sprintf("http://%s/create", ctx.String("volmaster")), "application/json", bytes.NewBuffer(content))
 	if err != nil {
-		return false, err
+		return false, errored.Errorf("Error in request: %v", err)
 	}
 
 	if resp.StatusCode != 200 {

--- a/volmaster/daemon.go
+++ b/volmaster/daemon.go
@@ -69,6 +69,11 @@ func (d *DaemonConfig) Daemon(debug bool, listen string) {
 	go func() {
 		for {
 			d.Global = (<-activity).Config.(*config.Global)
+
+			if d.Global.Debug {
+				errored.AlwaysDebug = true
+				errored.AlwaysTrace = true
+			}
 		}
 	}()
 

--- a/volmaster/daemon.go
+++ b/volmaster/daemon.go
@@ -586,10 +586,15 @@ func (d *DaemonConfig) handleCreate(w http.ResponseWriter, r *http.Request) {
 		Hostname: hostname,
 	}
 
-	err = lock.NewDriver(d.Config).ExecuteWithUseLock(uc, func(ld *lock.Driver, uc config.UseLocker) error {
+	snapUC := &config.UseSnapshot{
+		Volume: volConfig,
+		Reason: lock.ReasonCreate,
+	}
+
+	err = lock.NewDriver(d.Config).ExecuteWithMultiUseLock([]config.UseLocker{uc, snapUC}, true, d.Global.Timeout, func(ld *lock.Driver, ucs []config.UseLocker) error {
 		do, err := d.createVolume(policy, volConfig, d.Global.Timeout)
 		if err == storage.ErrVolumeExist {
-			log.Errorf("Volume exists, cleaning up")
+			log.Errorf("Volume %v exists, cleaning up", volConfig)
 			return nil
 		} else if err != nil {
 			return errored.Errorf("Creating volume").Combine(err.(*errored.Error))

--- a/volmaster/daemon.go
+++ b/volmaster/daemon.go
@@ -448,22 +448,22 @@ func (d *DaemonConfig) handleRemove(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if !exists {
-			return errored.Errorf("Volume %q no longer exists", vc.String())
+			return errored.Errorf("Volume %v no longer exists", vc)
 		}
 
 		if err := d.removeVolume(vc, d.Global.Timeout); err != nil {
-			return errored.Errorf("Removing image").Combine(err.(*errored.Error))
+			return errored.Errorf("Removing image %q", vc).Combine(err.(*errored.Error))
 		}
 
 		if err := ld.Config.RemoveVolume(req.Policy, req.Volume); err != nil {
-			return errored.Errorf("Clearing volume records").Combine(err.(*errored.Error))
+			return errored.Errorf("Clearing volume records for %q", vc).Combine(err.(*errored.Error))
 		}
 
 		return nil
 	})
 
 	if err != nil {
-		httpError(w, "Removing volume", err)
+		httpError(w, fmt.Sprintf("Removing volume %v", vc), err)
 		return
 	}
 }

--- a/volmaster/daemon.go
+++ b/volmaster/daemon.go
@@ -452,11 +452,11 @@ func (d *DaemonConfig) handleRemove(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if err := d.removeVolume(vc, d.Global.Timeout); err != nil {
-			return errored.Errorf("Removing image %q", vc).Combine(err.(*errored.Error))
+			return errored.Errorf("Removing image %q", vc).Combine(err)
 		}
 
 		if err := ld.Config.RemoveVolume(req.Policy, req.Volume); err != nil {
-			return errored.Errorf("Clearing volume records for %q", vc).Combine(err.(*errored.Error))
+			return errored.Errorf("Clearing volume records for %q", vc).Combine(err)
 		}
 
 		return nil
@@ -597,14 +597,14 @@ func (d *DaemonConfig) handleCreate(w http.ResponseWriter, r *http.Request) {
 			log.Errorf("Volume %v exists, cleaning up", volConfig)
 			return nil
 		} else if err != nil {
-			return errored.Errorf("Creating volume").Combine(err.(*errored.Error))
+			return errored.Errorf("Creating volume").Combine(err)
 		}
 
 		if err := d.formatVolume(volConfig, do); err != nil {
 			if err := d.removeVolume(volConfig, d.Global.Timeout); err != nil {
 				log.Errorf("Error during cleanup of failed format: %v", err)
 			}
-			return errored.Errorf("Formatting volume").Combine(err.(*errored.Error))
+			return errored.Errorf("Formatting volume").Combine(err)
 		}
 
 		if err := ld.Config.PublishVolume(volConfig); err != nil && err != config.ErrExist {

--- a/volplugin/handlers.go
+++ b/volplugin/handlers.go
@@ -173,6 +173,7 @@ func (dc *DaemonConfig) remove(w http.ResponseWriter, r *http.Request) {
 				"pool": vc.Options.Pool,
 			},
 		},
+		Timeout: dc.Global.Timeout,
 	}
 
 	writeResponse(w, r, &VolumeResponse{Mountpoint: driver.MountPath(do), Err: ""})
@@ -224,6 +225,7 @@ func (dc *DaemonConfig) getPath(w http.ResponseWriter, r *http.Request) {
 				"pool": volConfig.Options.Pool,
 			},
 		},
+		Timeout: dc.Global.Timeout,
 	}
 
 	// FIXME need to ensure that the mount exists before returning to docker
@@ -273,6 +275,7 @@ func (dc *DaemonConfig) mount(w http.ResponseWriter, r *http.Request) {
 		FSOptions: storage.FSOptions{
 			Type: volConfig.Options.FileSystem,
 		},
+		Timeout: dc.Global.Timeout,
 	}
 
 	// if we're mounted already on this host, the mount publish will succeed and
@@ -353,6 +356,7 @@ func (dc *DaemonConfig) unmount(w http.ResponseWriter, r *http.Request) {
 				"pool": volConfig.Options.Pool,
 			},
 		},
+		Timeout: dc.Global.Timeout,
 	}
 
 	ut := &config.UseMount{

--- a/volplugin/volplugin.go
+++ b/volplugin/volplugin.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	log "github.com/Sirupsen/logrus"
+	"github.com/contiv/errored"
 	"github.com/contiv/volplugin/config"
 	"github.com/contiv/volplugin/info"
 	"github.com/contiv/volplugin/lock/client"
@@ -71,10 +72,6 @@ func (dc *DaemonConfig) Daemon() error {
 
 	if err := dc.updateMounts(); err != nil {
 		return err
-	}
-
-	if dc.Global.Debug {
-		log.SetLevel(log.DebugLevel)
 	}
 
 	go info.HandleDebugSignal()
@@ -175,6 +172,12 @@ func (dc *DaemonConfig) watchGlobal() error {
 	for {
 		time.Sleep(1 * time.Second)
 		dc.getGlobal()
+
+		if dc.Global.Debug {
+			log.SetLevel(log.DebugLevel)
+			errored.AlwaysTrace = true
+			errored.AlwaysDebug = true
+		}
 	}
 }
 

--- a/volplugin/volplugin.go
+++ b/volplugin/volplugin.go
@@ -223,8 +223,7 @@ func (dc *DaemonConfig) updateMounts() error {
 				}
 			}
 
-			stop := dc.Client.AddStopChan(mount.Volume.Name)
-			go dc.Client.HeartbeatMount(dc.Global.TTL, payload, stop)
+			go dc.Client.HeartbeatMount(dc.Global.TTL, payload, dc.Client.AddStopChan(mount.Volume.Name))
 		}
 	}
 


### PR DESCRIPTION
This branch contains a much more emboldened battery test suite (50 containers x 3 nodes + 50 volumes) that exposed a number of races that only appear under stress. I have almost all of them shaked out now. 

There are a few small fixes in here too, as well as some code cleanup/simplification around the system tests and ceph driver specifically.