### PR TITLE
Runtime configuration

### DIFF
--- a/config/merge.go
+++ b/config/merge.go
@@ -12,7 +12,7 @@ import (
 //
 // most of the work is done in setKey() and setValueWithType().
 //
-func mergeOpts(v *VolumeOptions, opts map[string]string) error {
+func mergeOpts(v *RuntimeOptions, opts map[string]string) error {
 	for key, value := range opts {
 		ptrVal := reflect.ValueOf(v)
 		if err := setKey(reflect.TypeOf(*v), &ptrVal, key, value); err != nil {

--- a/config/merge_test.go
+++ b/config/merge_test.go
@@ -5,9 +5,8 @@ import (
 )
 
 func (s *configSuite) TestMerge(c *C) {
-	v := VolumeOptions{}
+	v := RuntimeOptions{}
 	opts := map[string]string{
-		"size":                "10MB",
 		"snapshots":           "false",
 		"snapshots.frequency": "10m",
 		"snapshots.keep":      "20",
@@ -15,7 +14,6 @@ func (s *configSuite) TestMerge(c *C) {
 
 	c.Assert(mergeOpts(&v, opts), IsNil)
 	c.Assert(v.UseSnapshots, Equals, false)
-	c.Assert(v.Size, Equals, "10MB")
 	c.Assert(v.Snapshot.Keep, Equals, uint(20))
 	c.Assert(v.Snapshot.Frequency, Equals, "10m")
 }

--- a/config/policy.go
+++ b/config/policy.go
@@ -11,16 +11,17 @@ import (
 // Policy is the configuration of the policy. It includes default
 // information for items such as pool and volume configuration.
 type Policy struct {
-	DefaultVolumeOptions VolumeOptions     `json:"default-options"`
-	FileSystems          map[string]string `json:"filesystems"`
+	CreateOptions  `json:"create"`
+	RuntimeOptions `json:"runtime"`
+	DriverOptions  map[string]string `json:"driver"`
+	FileSystems    map[string]string `json:"filesystems"`
+	Backend        string
 }
 
 // NewPolicy return policy config with specified backend preset
 func NewPolicy(backend string) *Policy {
 	return &Policy{
-		DefaultVolumeOptions: VolumeOptions{
-			Backend: backend,
-		},
+		Backend: backend,
 	}
 }
 
@@ -36,7 +37,7 @@ func (c *Client) policy(name string) string {
 
 // PublishPolicy publishes policy intent to the configuration store.
 func (c *Client) PublishPolicy(name string, cfg *Policy) error {
-	if err := cfg.DefaultVolumeOptions.computeSize(); err != nil {
+	if err := cfg.CreateOptions.computeSize(); err != nil {
 		return err
 	}
 
@@ -107,5 +108,9 @@ func (cfg *Policy) Validate() error {
 		cfg.FileSystems = defaultFilesystems
 	}
 
-	return cfg.DefaultVolumeOptions.Validate()
+	if err := cfg.CreateOptions.Validate(); err != nil {
+		return err
+	}
+
+	return cfg.RuntimeOptions.Validate()
 }

--- a/config/policy_test.go
+++ b/config/policy_test.go
@@ -2,80 +2,94 @@ package config
 
 import . "gopkg.in/check.v1"
 
-var testPolicys = map[string]*Policy{
+var testPolicies = map[string]*Policy{
 	"basic": {
-		DefaultVolumeOptions: VolumeOptions{
-			Pool:         "rbd",
-			Size:         "10MB",
-			UseSnapshots: false,
-			FileSystem:   defaultFilesystem,
+		Backend:       "ceph",
+		DriverOptions: map[string]string{"pool": "rbd"},
+		CreateOptions: CreateOptions{
+			Size:       "10MB",
+			FileSystem: defaultFilesystem,
 		},
 		FileSystems: defaultFilesystems,
 	},
 	"basic2": {
-		DefaultVolumeOptions: VolumeOptions{
-			Pool:         "rbd",
-			Size:         "20MB",
-			UseSnapshots: false,
-			FileSystem:   defaultFilesystem,
+		Backend:       "ceph",
+		DriverOptions: map[string]string{"pool": "rbd"},
+		CreateOptions: CreateOptions{
+			Size:       "20MB",
+			FileSystem: defaultFilesystem,
 		},
 		FileSystems: defaultFilesystems,
 	},
 	"untouchedwithzerosize": {
-		DefaultVolumeOptions: VolumeOptions{
-			Pool:         "rbd",
-			Size:         "0",
-			UseSnapshots: false,
-			FileSystem:   defaultFilesystem,
+		Backend:       "ceph",
+		DriverOptions: map[string]string{"pool": "rbd"},
+		CreateOptions: CreateOptions{
+			Size:       "0",
+			FileSystem: defaultFilesystem,
 		},
 		FileSystems: defaultFilesystems,
 	},
 	"nilfs": {
-		DefaultVolumeOptions: VolumeOptions{
-			Pool:         "rbd",
-			Size:         "20MB",
-			UseSnapshots: false,
-			FileSystem:   defaultFilesystem,
-		},
-		FileSystems: defaultFilesystems,
-	},
-	"nopool": {
-		DefaultVolumeOptions: VolumeOptions{
-			Size:         "20MB",
-			UseSnapshots: false,
-			FileSystem:   defaultFilesystem,
+		Backend:       "ceph",
+		DriverOptions: map[string]string{"pool": "rbd"},
+		CreateOptions: CreateOptions{
+			Size:       "20MB",
+			FileSystem: defaultFilesystem,
 		},
 		FileSystems: defaultFilesystems,
 	},
 	"badsize": {
-		DefaultVolumeOptions: VolumeOptions{
-			Size:         "0",
-			UseSnapshots: false,
-			FileSystem:   defaultFilesystem,
+		Backend:       "ceph",
+		DriverOptions: map[string]string{"pool": "rbd"},
+		CreateOptions: CreateOptions{
+			Size:       "0",
+			FileSystem: defaultFilesystem,
 		},
 		FileSystems: defaultFilesystems,
 	},
 	"badsize2": {
-		DefaultVolumeOptions: VolumeOptions{
-			Size:         "10M",
-			UseSnapshots: false,
-			FileSystem:   defaultFilesystem,
+		Backend:       "ceph",
+		DriverOptions: map[string]string{"pool": "rbd"},
+		CreateOptions: CreateOptions{
+			Size:       "10M",
+			FileSystem: defaultFilesystem,
 		},
 		FileSystems: defaultFilesystems,
 	},
 	"badsize3": {
-		DefaultVolumeOptions: VolumeOptions{
-			Size:         "not a number",
-			UseSnapshots: false,
-			FileSystem:   defaultFilesystem,
+		Backend:       "ceph",
+		DriverOptions: map[string]string{"pool": "rbd"},
+		CreateOptions: CreateOptions{
+			Size:       "not a number",
+			FileSystem: defaultFilesystem,
 		},
 		FileSystems: defaultFilesystems,
 	},
 	"badsnaps": {
-		DefaultVolumeOptions: VolumeOptions{
-			Size:         "10M",
+		Backend:       "ceph",
+		DriverOptions: map[string]string{"pool": "rbd"},
+		CreateOptions: CreateOptions{
+			Size:       "10MB",
+			FileSystem: defaultFilesystem,
+		},
+		RuntimeOptions: RuntimeOptions{
 			UseSnapshots: true,
-			FileSystem:   defaultFilesystem,
+			Snapshot: SnapshotConfig{
+				Keep:      0,
+				Frequency: "",
+			},
+		},
+		FileSystems: defaultFilesystems,
+	},
+	"nobackend": {
+		DriverOptions: map[string]string{"pool": "rbd"},
+		CreateOptions: CreateOptions{
+			Size:       "10MB",
+			FileSystem: defaultFilesystem,
+		},
+		RuntimeOptions: RuntimeOptions{
+			UseSnapshots: true,
 			Snapshot: SnapshotConfig{
 				Keep:      0,
 				Frequency: "",
@@ -86,17 +100,17 @@ var testPolicys = map[string]*Policy{
 }
 
 func (s *configSuite) TestBasicPolicy(c *C) {
-	c.Assert(s.tlc.PublishPolicy("quux", testPolicys["basic"]), IsNil)
+	c.Assert(s.tlc.PublishPolicy("quux", testPolicies["basic"]), IsNil)
 
 	cfg, err := s.tlc.GetPolicy("quux")
 	c.Assert(err, IsNil)
-	c.Assert(cfg, DeepEquals, testPolicys["basic"])
+	c.Assert(cfg, DeepEquals, testPolicies["basic"])
 
-	c.Assert(s.tlc.PublishPolicy("bar", testPolicys["basic2"]), IsNil)
+	c.Assert(s.tlc.PublishPolicy("bar", testPolicies["basic2"]), IsNil)
 
 	cfg, err = s.tlc.GetPolicy("bar")
 	c.Assert(err, IsNil)
-	c.Assert(cfg, DeepEquals, testPolicys["basic2"])
+	c.Assert(cfg, DeepEquals, testPolicies["basic2"])
 
 	policies, err := s.tlc.ListPolicies()
 	c.Assert(err, IsNil)
@@ -118,37 +132,37 @@ func (s *configSuite) TestBasicPolicy(c *C) {
 
 	cfg, err = s.tlc.GetPolicy("quux")
 	c.Assert(err, IsNil)
-	c.Assert(cfg, DeepEquals, testPolicys["basic"])
+	c.Assert(cfg, DeepEquals, testPolicies["basic"])
 }
 
 func (s *configSuite) TestPolicyValidate(c *C) {
 	for _, key := range []string{"basic", "basic2", "nilfs"} {
-		c.Assert(testPolicys[key].Validate(), IsNil)
+		c.Assert(testPolicies[key].Validate(), IsNil)
 	}
 
 	// FIXME: ensure the default filesystem option is set when validate is called.
 	//        honestly, this both a pretty lousy way to do it and test it, we should do
 	//        something better.
-	c.Assert(testPolicys["nilfs"].FileSystems, DeepEquals, map[string]string{defaultFilesystem: "mkfs.ext4 -m0 %"})
+	c.Assert(testPolicies["nilfs"].FileSystems, DeepEquals, map[string]string{defaultFilesystem: "mkfs.ext4 -m0 %"})
 
-	c.Assert(testPolicys["untouchedwithzerosize"].Validate(), NotNil)
-	c.Assert(testPolicys["nopool"].Validate(), NotNil)
-	c.Assert(testPolicys["badsize"].Validate(), NotNil)
-	c.Assert(testPolicys["badsize2"].Validate(), NotNil)
-	_, err := testPolicys["badsize3"].DefaultVolumeOptions.ActualSize()
+	c.Assert(testPolicies["nobackend"].Validate(), NotNil)
+	c.Assert(testPolicies["untouchedwithzerosize"].Validate(), NotNil)
+	c.Assert(testPolicies["badsize"].Validate(), NotNil)
+	c.Assert(testPolicies["badsize2"].Validate(), NotNil)
+	_, err := testPolicies["badsize3"].CreateOptions.ActualSize()
 	c.Assert(err, NotNil)
 }
 
 func (s *configSuite) TestPolicyBadPublish(c *C) {
-	for _, key := range []string{"badsize", "badsize2", "badsize3", "nopool", "badsnaps"} {
-		c.Assert(s.tlc.PublishPolicy("test", testPolicys[key]), NotNil)
+	for _, key := range []string{"nobackend", "badsize", "badsize2", "badsize3", "badsnaps"} {
+		c.Assert(s.tlc.PublishPolicy("test", testPolicies[key]), NotNil)
 	}
 }
 
 func (s *configSuite) TestPolicyPublishEtcdDown(c *C) {
 	stopStartEtcd(c, func() {
 		for _, key := range []string{"basic", "basic2"} {
-			c.Assert(s.tlc.PublishPolicy("test", testPolicys[key]), NotNil)
+			c.Assert(s.tlc.PublishPolicy("test", testPolicies[key]), NotNil)
 		}
 	})
 }

--- a/config/volume_test.go
+++ b/config/volume_test.go
@@ -10,86 +10,94 @@ import (
 )
 
 func (s *configSuite) TestActualSize(c *C) {
-	vo := &VolumeOptions{Size: "10MB", UseSnapshots: false, Pool: "rbd"}
+	vo := &CreateOptions{Size: "10MB"}
 	actualSize, err := vo.ActualSize()
 	c.Assert(err, IsNil)
 	c.Assert(int(actualSize), Equals, 10)
 
-	vo = &VolumeOptions{Size: "1GB", UseSnapshots: false, Pool: "rbd"}
+	vo = &CreateOptions{Size: "1GB"}
 	actualSize, err = vo.ActualSize()
 	c.Assert(err, IsNil)
 	c.Assert(int(actualSize), Equals, 1024)
 
-	vo = &VolumeOptions{Size: "0", UseSnapshots: false, Pool: "rbd"}
+	vo = &CreateOptions{Size: "0"}
 	actualSize, err = vo.ActualSize()
 	c.Assert(err, IsNil)
 	c.Assert(int(actualSize), Equals, 0)
 
-	vo = &VolumeOptions{Size: "10M", UseSnapshots: false, Pool: "rbd"}
+	vo = &CreateOptions{Size: "10M"}
 	_, err = vo.ActualSize()
 	c.Assert(err, NotNil)
 
-	vo = &VolumeOptions{Size: "garbage", UseSnapshots: false, Pool: "rbd"}
+	vo = &CreateOptions{Size: "garbage"}
 	_, err = vo.ActualSize()
 	c.Assert(err, NotNil)
 }
 
 func (s *configSuite) TestVolumeValidate(c *C) {
 	vc := &Volume{
-		Options:    nil,
 		VolumeName: "foo",
 		PolicyName: "policy1",
 	}
 	c.Assert(vc.Validate(), NotNil)
 
 	vc = &Volume{
-		Options:    &VolumeOptions{Size: "10MB", UseSnapshots: false, Pool: "rbd", actualSize: 10},
-		VolumeName: "",
-		PolicyName: "policy1",
+		DriverOptions:  map[string]string{"pool": "rbd"},
+		CreateOptions:  CreateOptions{Size: "10MB", actualSize: 10},
+		RuntimeOptions: RuntimeOptions{UseSnapshots: false},
+		VolumeName:     "",
+		PolicyName:     "policy1",
 	}
 
 	c.Assert(vc.Validate(), NotNil)
 
 	vc = &Volume{
-		Options:    &VolumeOptions{Size: "10MB", UseSnapshots: false, Pool: "rbd", actualSize: 10},
-		VolumeName: "foo",
-		PolicyName: "",
+		DriverOptions:  map[string]string{"pool": "rbd"},
+		CreateOptions:  CreateOptions{Size: "10MB", actualSize: 10},
+		RuntimeOptions: RuntimeOptions{UseSnapshots: false},
+		VolumeName:     "foo",
+		PolicyName:     "",
 	}
 
 	c.Assert(vc.Validate(), NotNil)
 
 	vc = &Volume{
-		Options:    &VolumeOptions{Size: "10MB", UseSnapshots: false, Pool: "rbd", actualSize: 10},
-		VolumeName: "foo",
-		PolicyName: "policy1",
+		Backend:        "ceph",
+		DriverOptions:  map[string]string{"pool": "rbd"},
+		CreateOptions:  CreateOptions{Size: "10MB", actualSize: 10},
+		RuntimeOptions: RuntimeOptions{UseSnapshots: false},
+		VolumeName:     "foo",
+		PolicyName:     "policy1",
 	}
 
 	c.Assert(vc.Validate(), IsNil)
 }
 
 func (s *configSuite) TestVolumeOptionsValidate(c *C) {
-	opts := &VolumeOptions{}
+	opts := CreateOptions{}
 	c.Assert(opts.Validate(), NotNil)
+	opts2 := RuntimeOptions{}
+	c.Assert(opts2.Validate(), IsNil)
 
-	opts = &VolumeOptions{Size: "0"}
+	opts = CreateOptions{Size: "0"}
 	c.Assert(opts.Validate(), NotNil)
-	opts = &VolumeOptions{Size: "10MB", Pool: "rbd", actualSize: 10}
+	opts = CreateOptions{Size: "10MB", actualSize: 10}
 	c.Assert(opts.Validate(), IsNil)
 
-	opts = &VolumeOptions{Size: "10MB", UseSnapshots: true, Pool: "rbd", actualSize: 10}
-	c.Assert(opts.Validate(), NotNil)
-	opts = &VolumeOptions{Size: "10MB", UseSnapshots: true, Snapshot: SnapshotConfig{}, Pool: "rbd", actualSize: 10}
-	c.Assert(opts.Validate(), NotNil)
-	opts = &VolumeOptions{Size: "10MB", UseSnapshots: true, Snapshot: SnapshotConfig{Frequency: "10m", Keep: 0}, Pool: "rbd", actualSize: 10}
-	c.Assert(opts.Validate(), NotNil)
-	opts = &VolumeOptions{Size: "10MB", UseSnapshots: true, Snapshot: SnapshotConfig{Frequency: "", Keep: 10}, Pool: "rbd", actualSize: 10}
-	c.Assert(opts.Validate(), NotNil)
-	opts = &VolumeOptions{Size: "10MB", UseSnapshots: true, Snapshot: SnapshotConfig{Frequency: "10m", Keep: 10}, Pool: "rbd", actualSize: 10}
-	c.Assert(opts.Validate(), IsNil)
+	opts2 = RuntimeOptions{UseSnapshots: true}
+	c.Assert(opts2.Validate(), NotNil)
+	opts2 = RuntimeOptions{UseSnapshots: true, Snapshot: SnapshotConfig{}}
+	c.Assert(opts2.Validate(), NotNil)
+	opts2 = RuntimeOptions{UseSnapshots: true, Snapshot: SnapshotConfig{Frequency: "10m", Keep: 0}}
+	c.Assert(opts2.Validate(), NotNil)
+	opts2 = RuntimeOptions{UseSnapshots: true, Snapshot: SnapshotConfig{Frequency: "", Keep: 10}}
+	c.Assert(opts2.Validate(), NotNil)
+	opts2 = RuntimeOptions{UseSnapshots: true, Snapshot: SnapshotConfig{Frequency: "10m", Keep: 10}}
+	c.Assert(opts2.Validate(), IsNil)
 }
 
 func (s *configSuite) TestWatchVolumes(c *C) {
-	c.Assert(s.tlc.PublishPolicy("policy1", testPolicys["basic"]), IsNil)
+	c.Assert(s.tlc.PublishPolicy("policy1", testPolicies["basic"]), IsNil)
 	volumeChan := make(chan *watch.Watch)
 	s.tlc.WatchVolumes(volumeChan)
 
@@ -102,7 +110,9 @@ func (s *configSuite) TestWatchVolumes(c *C) {
 	volConfig := vol2.Config.(*Volume)
 	c.Assert(vol.PolicyName, Equals, volConfig.PolicyName)
 	c.Assert(vol.VolumeName, Equals, volConfig.VolumeName)
-	c.Assert(vol.Options, DeepEquals, volConfig.Options)
+	c.Assert(vol.CreateOptions, DeepEquals, volConfig.CreateOptions)
+	c.Assert(vol.RuntimeOptions, DeepEquals, volConfig.RuntimeOptions)
+	c.Assert(vol.DriverOptions, DeepEquals, volConfig.DriverOptions)
 }
 
 func (s *configSuite) TestVolumeCRUD(c *C) {
@@ -118,13 +128,10 @@ func (s *configSuite) TestVolumeCRUD(c *C) {
 
 	// populate the policies so the next few tests don't give false positives
 	for _, policy := range policyNames {
-		c.Assert(s.tlc.PublishPolicy(policy, testPolicys["basic"]), IsNil)
+		c.Assert(s.tlc.PublishPolicy(policy, testPolicies["basic"]), IsNil)
 	}
 
 	_, err = s.tlc.CreateVolume(RequestCreate{Policy: "foo", Volume: "bar", Opts: map[string]string{"quux": "derp"}})
-	c.Assert(err, NotNil)
-
-	_, err = s.tlc.CreateVolume(RequestCreate{Policy: "foo", Volume: "bar", Opts: map[string]string{"pool": ""}})
 	c.Assert(err, NotNil)
 
 	_, err = s.tlc.CreateVolume(RequestCreate{Policy: "foo", Volume: ""})
@@ -138,27 +145,22 @@ func (s *configSuite) TestVolumeCRUD(c *C) {
 
 	for _, policy := range policyNames {
 		for _, volume := range volumeNames {
-			vcfg, err := s.tlc.CreateVolume(RequestCreate{Policy: policy, Volume: volume, Opts: map[string]string{"filesystem": ""}})
+			vcfg, err := s.tlc.CreateVolume(RequestCreate{Policy: policy, Volume: volume})
 			c.Assert(err, IsNil)
 			c.Assert(s.tlc.PublishVolume(vcfg), IsNil)
 			c.Assert(s.tlc.PublishVolume(vcfg), Equals, ErrExist)
 
-			c.Assert(vcfg.Options.FileSystem, Equals, "ext4")
-
 			defer func(policy, volume string) { c.Assert(s.tlc.RemoveVolume(policy, volume), IsNil) }(policy, volume)
 
 			c.Assert(vcfg.VolumeName, Equals, volume)
-			opts := testPolicys["basic"].DefaultVolumeOptions
-			opts.Pool = "rbd"
-			c.Assert(vcfg.Options, DeepEquals, &opts)
 
 			vcfg2, err := s.tlc.GetVolume(policy, volume)
 			c.Assert(err, IsNil)
 
 			c.Assert(vcfg, DeepEquals, vcfg2)
 
-			vcfg.Options.Size = "0"
-			vcfg.Options.actualSize = 0
+			vcfg.CreateOptions.Size = "0"
+			vcfg.CreateOptions.actualSize = 0
 			c.Assert(s.tlc.PublishVolume(vcfg), NotNil)
 		}
 

--- a/lock/policy.json
+++ b/lock/policy.json
@@ -1,7 +1,12 @@
 {
-  "default-options": {
-    "pool": "rbd",
-    "size": "10MB",
+  "backend": "ceph",
+  "driver": {
+    "pool": "rbd"
+  },
+  "create": {
+    "size": "10MB"
+  },
+  "runtime": {
     "snapshots": true,
     "snapshot": {
       "frequency": "30m",

--- a/systemtests/integrated_test.go
+++ b/systemtests/integrated_test.go
@@ -43,22 +43,25 @@ func (s *systemtestSuite) TestIntegratedUseMountLock(c *C) {
 func (s *systemtestSuite) TestIntegratedMultiPool(c *C) {
 	defer s.mon0cmd("sudo ceph osd pool delete test test --yes-i-really-really-mean-it")
 	_, err := s.mon0cmd("sudo ceph osd pool create test 1 1")
+	c.Assert(err, IsNil)
 
-	c.Assert(s.createVolume("mon0", "policy1", "test", map[string]string{"pool": "test"}), IsNil)
+	_, err = s.uploadIntent("testpool", "testpool")
+	c.Assert(err, IsNil)
 
-	out, err := s.volcli("volume get policy1/test")
+	c.Assert(s.createVolume("mon0", "testpool", "test", nil), IsNil)
+
+	out, err := s.volcli("volume get testpool/test")
 	c.Assert(err, IsNil)
 
 	vc := &config.Volume{}
 	c.Assert(json.Unmarshal([]byte(out), vc), IsNil)
-	actualSize, err := vc.Options.ActualSize()
+	actualSize, err := vc.CreateOptions.ActualSize()
 	c.Assert(err, IsNil)
 	c.Assert(actualSize, Equals, uint64(10))
 }
 
 func (s *systemtestSuite) TestIntegratedDriverOptions(c *C) {
 	opts := map[string]string{
-		"size":                "200MB",
 		"snapshots":           "true",
 		"snapshots.frequency": "100m",
 		"snapshots.keep":      "20",
@@ -73,56 +76,8 @@ func (s *systemtestSuite) TestIntegratedDriverOptions(c *C) {
 
 	vc := &config.Volume{}
 	c.Assert(json.Unmarshal([]byte(out), vc), IsNil)
-	actualSize, err := vc.Options.ActualSize()
-	c.Assert(err, IsNil)
-	c.Assert(actualSize, Equals, uint64(200))
-	c.Assert(vc.Options.Snapshot.Frequency, Equals, "100m")
-	c.Assert(vc.Options.Snapshot.Keep, Equals, uint(20))
-}
-
-func (s *systemtestSuite) TestIntegratedMultipleFileSystems(c *C) {
-	_, err := s.uploadIntent("policy2", "fs")
-	c.Assert(err, IsNil)
-
-	opts := map[string]string{
-		"size": "1GB",
-	}
-
-	c.Assert(s.createVolume("mon0", "policy2", "test", opts), IsNil)
-	c.Assert(s.vagrant.GetNode("mon0").RunCommand("docker run -d -v policy2/test:/mnt alpine sleep 10m"), IsNil)
-
-	out, err := s.vagrant.GetNode("mon0").RunCommandWithOutput("mount -l -t btrfs")
-	c.Assert(err, IsNil)
-
-	lines := strings.Split(out, "\n")
-	pass := false
-	for _, line := range lines {
-		// cheat.
-		if strings.Contains(line, "/dev/rbd") {
-			pass = true
-			break
-		}
-	}
-
-	c.Assert(pass, Equals, true)
-	c.Assert(s.createVolume("mon0", "policy2", "testext4", map[string]string{"filesystem": "ext4"}), IsNil)
-
-	c.Assert(s.vagrant.GetNode("mon0").RunCommand("docker run -d -v policy2/testext4:/mnt alpine sleep 10m"), IsNil)
-
-	out, err = s.vagrant.GetNode("mon0").RunCommandWithOutput("mount -l -t ext4")
-	c.Assert(err, IsNil)
-
-	lines = strings.Split(out, "\n")
-	pass = false
-	for _, line := range lines {
-		// cheat.
-		if strings.Contains(line, "/dev/rbd") {
-			pass = true
-			break
-		}
-	}
-
-	c.Assert(pass, Equals, true)
+	c.Assert(vc.RuntimeOptions.Snapshot.Frequency, Equals, "100m")
+	c.Assert(vc.RuntimeOptions.Snapshot.Keep, Equals, uint(20))
 }
 
 func (s *systemtestSuite) TestIntegratedRateLimiting(c *C) {

--- a/systemtests/testdata/fastsnap.json
+++ b/systemtests/testdata/fastsnap.json
@@ -1,7 +1,12 @@
 { 
-  "default-options": {
-    "pool": "rbd",
-    "size": "10MB",
+  "backend": "ceph",
+  "driver": {
+    "pool": "rbd"
+  },
+  "create": {
+    "size": "10MB"
+  },
+  "runtime": {
     "snapshots": true,
     "snapshot": {
       "frequency": "2s",

--- a/systemtests/testdata/fs.json
+++ b/systemtests/testdata/fs.json
@@ -1,13 +1,18 @@
 { 
-  "default-options": {
-    "pool": "rbd",
+  "backend": "ceph",
+  "driver": {
+    "pool": "rbd"
+  },
+  "create": {
     "size": "10MB",
+    "filesystem": "btrfs"
+  },
+  "runtime": {
     "snapshots": true,
     "snapshot": {
       "frequency": "30m",
       "keep": 20
-    },
-    "filesystem": "btrfs"
+    }
   },
   "filesystems": {
     "ext4": "mkfs.ext4 -m0 %",

--- a/systemtests/testdata/nosnap.json
+++ b/systemtests/testdata/nosnap.json
@@ -1,7 +1,12 @@
 { 
-  "default-options": {
-    "pool": "rbd",
-    "size": "10MB",
+  "backend": "ceph",
+  "driver": {
+    "pool": "rbd"
+  },
+  "create": {
+    "size": "10MB"
+  },
+  "runtime": {
     "snapshots": false
   }
 }

--- a/systemtests/testdata/nulldriver.json
+++ b/systemtests/testdata/nulldriver.json
@@ -1,12 +1,16 @@
 { 
-  "default-options": {
-    "pool": "rbd",
-    "size": "10MB",
+  "backend": "null",
+  "driver": {
+    "pool": "rbd"
+  },
+  "create": {
+    "size": "10MB"
+  },
+  "runtime": {
     "snapshots": true,
     "snapshot": {
       "frequency": "30m",
       "keep": 20
-    },
-    "backend" : "null"
+    }
   }
 }

--- a/systemtests/testdata/policy1.json
+++ b/systemtests/testdata/policy1.json
@@ -1,7 +1,12 @@
 { 
-  "default-options": {
-    "pool": "rbd",
-    "size": "10MB",
+  "backend": "ceph",
+  "driver": {
+    "pool": "rbd"
+  },
+  "create": {
+    "size": "10MB"
+  },
+  "runtime": {
     "snapshots": true,
     "snapshot": {
       "frequency": "30m",

--- a/systemtests/testdata/testpool.json
+++ b/systemtests/testdata/testpool.json
@@ -1,16 +1,16 @@
-{ 
+{
   "backend": "ceph",
   "driver": {
-    "pool": "rbd"
+    "pool": "test"
   },
   "create": {
-    "size": "100MB"
+    "size": "10MB"
   },
   "runtime": {
     "snapshots": true,
     "snapshot": {
-      "frequency": "1m",
-      "keep": 10
+      "frequency": "30m",
+      "keep": 20
     }
   }
 }

--- a/systemtests/volcli_test.go
+++ b/systemtests/volcli_test.go
@@ -115,14 +115,14 @@ func (s *systemtestSuite) TestVolCLIVolume(c *C) {
 
 	c.Assert(json.Unmarshal([]byte(out), cfg), IsNil)
 
-	cfg.Options.FileSystem = "ext4"
+	cfg.CreateOptions.FileSystem = "ext4"
 
 	policy1, err := s.readIntent("testdata/policy1.json")
 	c.Assert(err, IsNil)
 
-	policy1.DefaultVolumeOptions.FileSystem = "ext4"
+	policy1.CreateOptions.FileSystem = "ext4"
 
-	c.Assert(policy1.DefaultVolumeOptions, DeepEquals, *cfg.Options)
+	c.Assert(policy1.CreateOptions, DeepEquals, cfg.CreateOptions)
 
 	_, err = s.volcli("volume remove policy1/foo")
 	c.Assert(err, IsNil)
@@ -144,12 +144,13 @@ func (s *systemtestSuite) TestVolCLIVolume(c *C) {
 
 	cfg = &config.Volume{}
 	c.Assert(json.Unmarshal([]byte(out), cfg), IsNil)
-	cfg.Options.FileSystem = "ext4"
+	cfg.CreateOptions.FileSystem = "ext4"
 	policy1, err = s.readIntent("testdata/policy1.json")
 	c.Assert(err, IsNil)
-	policy1.DefaultVolumeOptions.FileSystem = "ext4"
-	policy1.DefaultVolumeOptions.UseSnapshots = false
-	c.Assert(policy1.DefaultVolumeOptions, DeepEquals, *cfg.Options)
+	policy1.CreateOptions.FileSystem = "ext4"
+	policy1.RuntimeOptions.UseSnapshots = false
+	c.Assert(policy1.CreateOptions, DeepEquals, cfg.CreateOptions)
+	c.Assert(policy1.RuntimeOptions, DeepEquals, cfg.RuntimeOptions)
 }
 
 func (s *systemtestSuite) TestVolCLIVolumePolicyUpdate(c *C) {

--- a/systemtests/volmaster_test.go
+++ b/systemtests/volmaster_test.go
@@ -14,6 +14,7 @@ func (s *systemtestSuite) TestVolmasterNoGlobalConfiguration(c *C) {
 	_, err := s.mon0cmd("etcdctl rm /volplugin/global-config")
 	c.Assert(err, IsNil)
 	c.Assert(s.vagrant.IterateNodes(startVolmaster), IsNil)
+	c.Assert(s.vagrant.IterateNodes(waitForVolmaster), IsNil)
 
 	c.Assert(s.createVolume("mon0", "policy1", "test", nil), IsNil)
 	_, err = s.docker("run -v policy1/test:/mnt alpine echo")

--- a/systemtests/volume_test.go
+++ b/systemtests/volume_test.go
@@ -67,28 +67,6 @@ func (s *systemtestSuite) TestVolumeMultiPolicyCreate(c *C) {
 	c.Assert(err, NotNil)
 }
 
-func (s *systemtestSuite) TestVolumeEphemeral(c *C) {
-	c.Assert(s.createVolume("mon0", "policy1", "test", map[string]string{"ephemeral": "true"}), IsNil)
-	out, err := s.vagrant.GetNode("mon0").RunCommandWithOutput("sudo rbd ls")
-	c.Assert(err, IsNil)
-	c.Assert(strings.TrimSpace(out), Equals, "policy1.test")
-
-	c.Assert(s.vagrant.GetNode("mon0").RunCommand("docker volume rm policy1/test"), IsNil)
-	out, err = s.vagrant.GetNode("mon0").RunCommandWithOutput("sudo rbd ls")
-	c.Assert(err, IsNil)
-	c.Assert(strings.TrimSpace(out), Not(Equals), "policy1.test")
-
-	c.Assert(s.createVolume("mon0", "policy1", "test", map[string]string{"ephemeral": "false"}), IsNil)
-	out, err = s.vagrant.GetNode("mon0").RunCommandWithOutput("sudo rbd ls")
-	c.Assert(err, IsNil)
-	c.Assert(strings.TrimSpace(out), Equals, "policy1.test")
-
-	c.Assert(s.vagrant.GetNode("mon0").RunCommand("docker volume rm policy1/test"), IsNil)
-	out, err = s.vagrant.GetNode("mon0").RunCommandWithOutput("sudo rbd ls")
-	c.Assert(err, IsNil)
-	c.Assert(strings.TrimSpace(out), Equals, "policy1.test")
-}
-
 func (s *systemtestSuite) TestVolumeParallelCreate(c *C) {
 	c.Assert(s.vagrant.IterateNodes(func(node vagrantssh.TestbedNode) error {
 		return node.RunCommand("docker volume create -d volplugin --name policy1/test")

--- a/volmaster/daemon.go
+++ b/volmaster/daemon.go
@@ -165,10 +165,8 @@ func (d *DaemonConfig) handleSnapshotList(w http.ResponseWriter, r *http.Request
 
 	do := storage.DriverOptions{
 		Volume: storage.Volume{
-			Name: intName,
-			Params: storage.Params{
-				"pool": volConfig.Options.Pool,
-			},
+			Name:   intName,
+			Params: volConfig.DriverOptions,
 		},
 		Timeout: d.Global.Timeout,
 	}
@@ -238,10 +236,8 @@ func (d *DaemonConfig) handleCopy(w http.ResponseWriter, r *http.Request) {
 
 	do := storage.DriverOptions{
 		Volume: storage.Volume{
-			Name: intName,
-			Params: storage.Params{
-				"pool": volConfig.Options.Pool,
-			},
+			Name:   intName,
+			Params: volConfig.DriverOptions,
 		},
 		Timeout: d.Global.Timeout,
 	}
@@ -328,7 +324,7 @@ func (d *DaemonConfig) handleList(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		driver, err := backend.NewDriver(volConfig.Options.Backend, d.Global.MountPath)
+		driver, err := backend.NewDriver(volConfig.Backend, d.Global.MountPath)
 		if err != nil {
 			httpError(w, "Initializing driver", err)
 			return
@@ -342,10 +338,8 @@ func (d *DaemonConfig) handleList(w http.ResponseWriter, r *http.Request) {
 
 		do := storage.DriverOptions{
 			Volume: storage.Volume{
-				Name: intName,
-				Params: storage.Params{
-					"pool": volConfig.Options.Pool,
-				},
+				Name:   intName,
+				Params: volConfig.DriverOptions,
 			},
 			Timeout: d.Global.Timeout,
 		}
@@ -378,7 +372,7 @@ func (d *DaemonConfig) handleGet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	driver, err := backend.NewDriver(volConfig.Options.Backend, d.Global.MountPath)
+	driver, err := backend.NewDriver(volConfig.Backend, d.Global.MountPath)
 	if err != nil {
 		httpError(w, "Initializing backend", err)
 		return
@@ -392,10 +386,8 @@ func (d *DaemonConfig) handleGet(w http.ResponseWriter, r *http.Request) {
 
 	do := storage.DriverOptions{
 		Volume: storage.Volume{
-			Name: intName,
-			Params: storage.Params{
-				"pool": volConfig.Options.Pool,
-			},
+			Name:   intName,
+			Params: volConfig.DriverOptions,
 		},
 		Timeout: d.Global.Timeout,
 	}

--- a/volplugin/cgroup.go
+++ b/volplugin/cgroup.go
@@ -22,10 +22,10 @@ func makeLimit(mc *storage.Mount, limit uint64) []byte {
 
 func applyCGroupRateLimit(vc *config.Volume, mc *storage.Mount) error {
 	opMap := map[string]uint64{
-		writeIOPSFile: uint64(vc.Options.RateLimit.WriteIOPS),
-		readIOPSFile:  uint64(vc.Options.RateLimit.ReadIOPS),
-		writeBPSFile:  vc.Options.RateLimit.WriteBPS,
-		readBPSFile:   vc.Options.RateLimit.ReadBPS,
+		writeIOPSFile: uint64(vc.RuntimeOptions.RateLimit.WriteIOPS),
+		readIOPSFile:  uint64(vc.RuntimeOptions.RateLimit.ReadIOPS),
+		writeBPSFile:  vc.RuntimeOptions.RateLimit.WriteBPS,
+		readBPSFile:   vc.RuntimeOptions.RateLimit.ReadBPS,
 	}
 
 	for fn, val := range opMap {

--- a/volplugin/handlers.go
+++ b/volplugin/handlers.go
@@ -148,14 +148,7 @@ func (dc *DaemonConfig) remove(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if vc.Options.Ephemeral {
-		if err := dc.requestRemove(uc.Policy, uc.Name); err != nil {
-			httpError(w, "Removing ephemeral volume", err)
-			return
-		}
-	}
-
-	driver, err := backend.NewDriver(vc.Options.Backend, dc.Global.MountPath)
+	driver, err := backend.NewDriver(vc.Backend, dc.Global.MountPath)
 	if err != nil {
 		httpError(w, fmt.Sprintf("loading driver"), err)
 		return
@@ -168,10 +161,8 @@ func (dc *DaemonConfig) remove(w http.ResponseWriter, r *http.Request) {
 
 	do := storage.DriverOptions{
 		Volume: storage.Volume{
-			Name: name,
-			Params: storage.Params{
-				"pool": vc.Options.Pool,
-			},
+			Name:   name,
+			Params: vc.DriverOptions,
 		},
 		Timeout: dc.Global.Timeout,
 	}
@@ -207,7 +198,7 @@ func (dc *DaemonConfig) getPath(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	driver, err := backend.NewDriver(volConfig.Options.Backend, dc.Global.MountPath)
+	driver, err := backend.NewDriver(volConfig.Backend, dc.Global.MountPath)
 	if err != nil {
 		httpError(w, fmt.Sprintf("loading driver"), err)
 		return
@@ -220,10 +211,8 @@ func (dc *DaemonConfig) getPath(w http.ResponseWriter, r *http.Request) {
 
 	do := storage.DriverOptions{
 		Volume: storage.Volume{
-			Name: name,
-			Params: storage.Params{
-				"pool": volConfig.Options.Pool,
-			},
+			Name:   name,
+			Params: volConfig.DriverOptions,
 		},
 		Timeout: dc.Global.Timeout,
 	}
@@ -246,7 +235,7 @@ func (dc *DaemonConfig) mount(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	driver, err := backend.NewDriver(volConfig.Options.Backend, dc.Global.MountPath)
+	driver, err := backend.NewDriver(volConfig.Backend, dc.Global.MountPath)
 	if err != nil {
 		httpError(w, fmt.Sprintf("loading driver"), err)
 		return
@@ -258,7 +247,7 @@ func (dc *DaemonConfig) mount(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	actualSize, err := volConfig.Options.ActualSize()
+	actualSize, err := volConfig.CreateOptions.ActualSize()
 	if err != nil {
 		httpError(w, "Computing size of volume", err)
 		return
@@ -266,14 +255,12 @@ func (dc *DaemonConfig) mount(w http.ResponseWriter, r *http.Request) {
 
 	driverOpts := storage.DriverOptions{
 		Volume: storage.Volume{
-			Name: intName,
-			Size: actualSize,
-			Params: storage.Params{
-				"pool": volConfig.Options.Pool,
-			},
+			Name:   intName,
+			Size:   actualSize,
+			Params: volConfig.DriverOptions,
 		},
 		FSOptions: storage.FSOptions{
-			Type: volConfig.Options.FileSystem,
+			Type: volConfig.CreateOptions.FileSystem,
 		},
 		Timeout: dc.Global.Timeout,
 	}
@@ -337,7 +324,7 @@ func (dc *DaemonConfig) unmount(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	driver, err := backend.NewDriver(volConfig.Options.Backend, dc.Global.MountPath)
+	driver, err := backend.NewDriver(volConfig.Backend, dc.Global.MountPath)
 	if err != nil {
 		httpError(w, fmt.Sprintf("loading driver"), err)
 		return
@@ -351,10 +338,8 @@ func (dc *DaemonConfig) unmount(w http.ResponseWriter, r *http.Request) {
 
 	driverOpts := storage.DriverOptions{
 		Volume: storage.Volume{
-			Name: intName,
-			Params: storage.Params{
-				"pool": volConfig.Options.Pool,
-			},
+			Name:   intName,
+			Params: volConfig.DriverOptions,
 		},
 		Timeout: dc.Global.Timeout,
 	}

--- a/volsupervisor/loop.go
+++ b/volsupervisor/loop.go
@@ -27,7 +27,7 @@ func (dc *DaemonConfig) pruneSnapshots(volume string, val *config.Volume) {
 	}
 
 	err := lock.NewDriver(dc.Config).ExecuteWithUseLock(uc, func(ld *lock.Driver, uc config.UseLocker) error {
-		driver, err := backend.NewDriver(val.Options.Backend, dc.Global.MountPath)
+		driver, err := backend.NewDriver(val.Backend, dc.Global.MountPath)
 		if err != nil {
 			log.Errorf("failed to get driver: %v", err)
 			return err
@@ -37,7 +37,7 @@ func (dc *DaemonConfig) pruneSnapshots(volume string, val *config.Volume) {
 			Volume: storage.Volume{
 				Name: strings.Join([]string{val.PolicyName, val.VolumeName}, "."),
 				Params: storage.Params{
-					"pool": val.Options.Pool,
+					"pool": val.DriverOptions["pool"],
 				},
 			},
 			Timeout: dc.Global.Timeout,
@@ -49,9 +49,9 @@ func (dc *DaemonConfig) pruneSnapshots(volume string, val *config.Volume) {
 			return err
 		}
 
-		log.Debugf("Volume %q: keeping %d snapshots", val, val.Options.Snapshot.Keep)
+		log.Debugf("Volume %q: keeping %d snapshots", val, val.RuntimeOptions.Snapshot.Keep)
 
-		toDeleteCount := len(list) - int(val.Options.Snapshot.Keep)
+		toDeleteCount := len(list) - int(val.RuntimeOptions.Snapshot.Keep)
 		if toDeleteCount < 0 {
 			return nil
 		}
@@ -80,9 +80,9 @@ func (dc *DaemonConfig) createSnapshot(volume string, val *config.Volume) {
 	}
 
 	err := lock.NewDriver(dc.Config).ExecuteWithUseLock(uc, func(ld *lock.Driver, uc config.UseLocker) error {
-		driver, err := backend.NewDriver(val.Options.Backend, dc.Global.MountPath)
+		driver, err := backend.NewDriver(val.Backend, dc.Global.MountPath)
 		if err != nil {
-			log.Errorf("Error establishing driver backend %q; cannot snapshot", val.Options.Backend)
+			log.Errorf("Error establishing driver backend %q; cannot snapshot", val.Backend)
 			return err
 		}
 
@@ -90,7 +90,7 @@ func (dc *DaemonConfig) createSnapshot(volume string, val *config.Volume) {
 			Volume: storage.Volume{
 				Name: strings.Join([]string{val.PolicyName, val.VolumeName}, "."),
 				Params: storage.Params{
-					"pool": val.Options.Pool,
+					"pool": val.DriverOptions["pool"],
 				},
 			},
 			Timeout: dc.Global.Timeout,
@@ -123,8 +123,8 @@ func (dc *DaemonConfig) loop() {
 		volumeMutex.Unlock()
 
 		for volume, val := range volumeCopy {
-			if val.Options.UseSnapshots {
-				freq, err := time.ParseDuration(val.Options.Snapshot.Frequency)
+			if val.RuntimeOptions.UseSnapshots {
+				freq, err := time.ParseDuration(val.RuntimeOptions.Snapshot.Frequency)
 				if err != nil {
 					log.Errorf("Volume %q has an invalid frequency. Skipping snapshot.", volume)
 				}


### PR DESCRIPTION
This changes the json structure to be less verbose and more descriptive. It also partitions the parameters into several portions over the single `default-options` before, allowing for better handling of runtime configuration vs. create time configuration, as well as passing static driver parameters.

Please see the testdata for the new format.
