### PR TITLE
Runtime configuration 4

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -33,5 +33,5 @@ func (s *configSuite) TestPrefixed(c *C) {
 	c.Assert(s.tlc.prefixed("foo"), Equals, path.Join(s.tlc.prefix, "foo"))
 	c.Assert(s.tlc.use("mount", &Volume{PolicyName: "bar", VolumeName: "baz"}), Equals, s.tlc.prefixed(rootUse, "mount", "bar", "baz"))
 	c.Assert(s.tlc.policy("quux"), Equals, s.tlc.prefixed(rootPolicy, "quux"))
-	c.Assert(s.tlc.volume("foo", "bar"), Equals, s.tlc.prefixed(rootVolume, "foo", "bar"))
+	c.Assert(s.tlc.volume("foo", "bar", "quux"), Equals, s.tlc.prefixed(rootVolume, "foo", "bar", "quux"))
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -31,7 +31,7 @@ func (s *configSuite) SetUpSuite(c *C) {
 
 func (s *configSuite) TestPrefixed(c *C) {
 	c.Assert(s.tlc.prefixed("foo"), Equals, path.Join(s.tlc.prefix, "foo"))
-	c.Assert(s.tlc.use("mount", &Volume{PolicyName: "bar", VolumeName: "baz"}), Equals, s.tlc.prefixed(rootUse, "mount", "bar", "baz"))
+	c.Assert(s.tlc.use("mount", "bar/baz"), Equals, s.tlc.prefixed(rootUse, "mount", "bar", "baz"))
 	c.Assert(s.tlc.policy("quux"), Equals, s.tlc.prefixed(rootPolicy, "quux"))
 	c.Assert(s.tlc.volume("foo", "bar", "quux"), Equals, s.tlc.prefixed(rootVolume, "foo", "bar", "quux"))
 }

--- a/config/merge.go
+++ b/config/merge.go
@@ -12,7 +12,7 @@ import (
 //
 // most of the work is done in setKey() and setValueWithType().
 //
-func mergeOpts(v *VolumeOptions, opts map[string]string) error {
+func mergeOpts(v *RuntimeOptions, opts map[string]string) error {
 	for key, value := range opts {
 		ptrVal := reflect.ValueOf(v)
 		if err := setKey(reflect.TypeOf(*v), &ptrVal, key, value); err != nil {

--- a/config/merge_test.go
+++ b/config/merge_test.go
@@ -5,9 +5,8 @@ import (
 )
 
 func (s *configSuite) TestMerge(c *C) {
-	v := VolumeOptions{}
+	v := RuntimeOptions{}
 	opts := map[string]string{
-		"size":                "10MB",
 		"snapshots":           "false",
 		"snapshots.frequency": "10m",
 		"snapshots.keep":      "20",
@@ -15,7 +14,6 @@ func (s *configSuite) TestMerge(c *C) {
 
 	c.Assert(mergeOpts(&v, opts), IsNil)
 	c.Assert(v.UseSnapshots, Equals, false)
-	c.Assert(v.Size, Equals, "10MB")
 	c.Assert(v.Snapshot.Keep, Equals, uint(20))
 	c.Assert(v.Snapshot.Frequency, Equals, "10m")
 }

--- a/config/merge_test.go
+++ b/config/merge_test.go
@@ -5,15 +5,19 @@ import (
 )
 
 func (s *configSuite) TestMerge(c *C) {
-	v := RuntimeOptions{}
+	p := &Policy{}
 	opts := map[string]string{
+		"size":                "200MB",
 		"snapshots":           "false",
 		"snapshots.frequency": "10m",
 		"snapshots.keep":      "20",
 	}
 
-	c.Assert(mergeOpts(&v, opts), IsNil)
-	c.Assert(v.UseSnapshots, Equals, false)
-	c.Assert(v.Snapshot.Keep, Equals, uint(20))
-	c.Assert(v.Snapshot.Frequency, Equals, "10m")
+	c.Assert(mergeOpts(p, opts), IsNil)
+	actualSize, err := p.CreateOptions.ActualSize()
+	c.Assert(err, IsNil)
+	c.Assert(actualSize, Equals, uint64(200))
+	c.Assert(p.RuntimeOptions.UseSnapshots, Equals, false)
+	c.Assert(p.RuntimeOptions.Snapshot.Keep, Equals, uint(20))
+	c.Assert(p.RuntimeOptions.Snapshot.Frequency, Equals, "10m")
 }

--- a/config/policy.go
+++ b/config/policy.go
@@ -11,16 +11,17 @@ import (
 // Policy is the configuration of the policy. It includes default
 // information for items such as pool and volume configuration.
 type Policy struct {
-	DefaultVolumeOptions VolumeOptions     `json:"default-options"`
-	FileSystems          map[string]string `json:"filesystems"`
+	CreateOptions  `json:"create"`
+	RuntimeOptions `json:"runtime"`
+	DriverOptions  map[string]string `json:"driver"`
+	FileSystems    map[string]string `json:"filesystems"`
+	Backend        string
 }
 
 // NewPolicy return policy config with specified backend preset
 func NewPolicy(backend string) *Policy {
 	return &Policy{
-		DefaultVolumeOptions: VolumeOptions{
-			Backend: backend,
-		},
+		Backend: backend,
 	}
 }
 
@@ -36,7 +37,7 @@ func (c *Client) policy(name string) string {
 
 // PublishPolicy publishes policy intent to the configuration store.
 func (c *Client) PublishPolicy(name string, cfg *Policy) error {
-	if err := cfg.DefaultVolumeOptions.computeSize(); err != nil {
+	if err := cfg.CreateOptions.computeSize(); err != nil {
 		return err
 	}
 
@@ -107,5 +108,9 @@ func (cfg *Policy) Validate() error {
 		cfg.FileSystems = defaultFilesystems
 	}
 
-	return cfg.DefaultVolumeOptions.Validate()
+	if err := cfg.CreateOptions.Validate(); err != nil {
+		return err
+	}
+
+	return cfg.RuntimeOptions.Validate()
 }

--- a/config/policy.go
+++ b/config/policy.go
@@ -11,11 +11,11 @@ import (
 // Policy is the configuration of the policy. It includes default
 // information for items such as pool and volume configuration.
 type Policy struct {
-	CreateOptions  `json:"create"`
-	RuntimeOptions `json:"runtime"`
+	CreateOptions  CreateOptions     `json:"create"`
+	RuntimeOptions RuntimeOptions    `json:"runtime"`
 	DriverOptions  map[string]string `json:"driver"`
 	FileSystems    map[string]string `json:"filesystems"`
-	Backend        string
+	Backend        string            `json:"backend"`
 }
 
 // NewPolicy return policy config with specified backend preset

--- a/config/policy_test.go
+++ b/config/policy_test.go
@@ -9,6 +9,14 @@ var testPolicies = map[string]*Policy{
 		CreateOptions: CreateOptions{
 			Size:       "10MB",
 			FileSystem: defaultFilesystem,
+			actualSize: 10,
+		},
+		RuntimeOptions: RuntimeOptions{
+			UseSnapshots: true,
+			Snapshot: SnapshotConfig{
+				Keep:      10,
+				Frequency: "1m",
+			},
 		},
 		FileSystems: defaultFilesystems,
 	},

--- a/config/policy_test.go
+++ b/config/policy_test.go
@@ -2,80 +2,94 @@ package config
 
 import . "gopkg.in/check.v1"
 
-var testPolicys = map[string]*Policy{
+var testPolicies = map[string]*Policy{
 	"basic": {
-		DefaultVolumeOptions: VolumeOptions{
-			Pool:         "rbd",
-			Size:         "10MB",
-			UseSnapshots: false,
-			FileSystem:   defaultFilesystem,
+		Backend:       "ceph",
+		DriverOptions: map[string]string{"pool": "rbd"},
+		CreateOptions: CreateOptions{
+			Size:       "10MB",
+			FileSystem: defaultFilesystem,
 		},
 		FileSystems: defaultFilesystems,
 	},
 	"basic2": {
-		DefaultVolumeOptions: VolumeOptions{
-			Pool:         "rbd",
-			Size:         "20MB",
-			UseSnapshots: false,
-			FileSystem:   defaultFilesystem,
+		Backend:       "ceph",
+		DriverOptions: map[string]string{"pool": "rbd"},
+		CreateOptions: CreateOptions{
+			Size:       "20MB",
+			FileSystem: defaultFilesystem,
 		},
 		FileSystems: defaultFilesystems,
 	},
 	"untouchedwithzerosize": {
-		DefaultVolumeOptions: VolumeOptions{
-			Pool:         "rbd",
-			Size:         "0",
-			UseSnapshots: false,
-			FileSystem:   defaultFilesystem,
+		Backend:       "ceph",
+		DriverOptions: map[string]string{"pool": "rbd"},
+		CreateOptions: CreateOptions{
+			Size:       "0",
+			FileSystem: defaultFilesystem,
 		},
 		FileSystems: defaultFilesystems,
 	},
 	"nilfs": {
-		DefaultVolumeOptions: VolumeOptions{
-			Pool:         "rbd",
-			Size:         "20MB",
-			UseSnapshots: false,
-			FileSystem:   defaultFilesystem,
-		},
-		FileSystems: defaultFilesystems,
-	},
-	"nopool": {
-		DefaultVolumeOptions: VolumeOptions{
-			Size:         "20MB",
-			UseSnapshots: false,
-			FileSystem:   defaultFilesystem,
+		Backend:       "ceph",
+		DriverOptions: map[string]string{"pool": "rbd"},
+		CreateOptions: CreateOptions{
+			Size:       "20MB",
+			FileSystem: defaultFilesystem,
 		},
 		FileSystems: defaultFilesystems,
 	},
 	"badsize": {
-		DefaultVolumeOptions: VolumeOptions{
-			Size:         "0",
-			UseSnapshots: false,
-			FileSystem:   defaultFilesystem,
+		Backend:       "ceph",
+		DriverOptions: map[string]string{"pool": "rbd"},
+		CreateOptions: CreateOptions{
+			Size:       "0",
+			FileSystem: defaultFilesystem,
 		},
 		FileSystems: defaultFilesystems,
 	},
 	"badsize2": {
-		DefaultVolumeOptions: VolumeOptions{
-			Size:         "10M",
-			UseSnapshots: false,
-			FileSystem:   defaultFilesystem,
+		Backend:       "ceph",
+		DriverOptions: map[string]string{"pool": "rbd"},
+		CreateOptions: CreateOptions{
+			Size:       "10M",
+			FileSystem: defaultFilesystem,
 		},
 		FileSystems: defaultFilesystems,
 	},
 	"badsize3": {
-		DefaultVolumeOptions: VolumeOptions{
-			Size:         "not a number",
-			UseSnapshots: false,
-			FileSystem:   defaultFilesystem,
+		Backend:       "ceph",
+		DriverOptions: map[string]string{"pool": "rbd"},
+		CreateOptions: CreateOptions{
+			Size:       "not a number",
+			FileSystem: defaultFilesystem,
 		},
 		FileSystems: defaultFilesystems,
 	},
 	"badsnaps": {
-		DefaultVolumeOptions: VolumeOptions{
-			Size:         "10M",
+		Backend:       "ceph",
+		DriverOptions: map[string]string{"pool": "rbd"},
+		CreateOptions: CreateOptions{
+			Size:       "10MB",
+			FileSystem: defaultFilesystem,
+		},
+		RuntimeOptions: RuntimeOptions{
 			UseSnapshots: true,
-			FileSystem:   defaultFilesystem,
+			Snapshot: SnapshotConfig{
+				Keep:      0,
+				Frequency: "",
+			},
+		},
+		FileSystems: defaultFilesystems,
+	},
+	"nobackend": {
+		DriverOptions: map[string]string{"pool": "rbd"},
+		CreateOptions: CreateOptions{
+			Size:       "10MB",
+			FileSystem: defaultFilesystem,
+		},
+		RuntimeOptions: RuntimeOptions{
+			UseSnapshots: true,
 			Snapshot: SnapshotConfig{
 				Keep:      0,
 				Frequency: "",
@@ -86,17 +100,17 @@ var testPolicys = map[string]*Policy{
 }
 
 func (s *configSuite) TestBasicPolicy(c *C) {
-	c.Assert(s.tlc.PublishPolicy("quux", testPolicys["basic"]), IsNil)
+	c.Assert(s.tlc.PublishPolicy("quux", testPolicies["basic"]), IsNil)
 
 	cfg, err := s.tlc.GetPolicy("quux")
 	c.Assert(err, IsNil)
-	c.Assert(cfg, DeepEquals, testPolicys["basic"])
+	c.Assert(cfg, DeepEquals, testPolicies["basic"])
 
-	c.Assert(s.tlc.PublishPolicy("bar", testPolicys["basic2"]), IsNil)
+	c.Assert(s.tlc.PublishPolicy("bar", testPolicies["basic2"]), IsNil)
 
 	cfg, err = s.tlc.GetPolicy("bar")
 	c.Assert(err, IsNil)
-	c.Assert(cfg, DeepEquals, testPolicys["basic2"])
+	c.Assert(cfg, DeepEquals, testPolicies["basic2"])
 
 	policies, err := s.tlc.ListPolicies()
 	c.Assert(err, IsNil)
@@ -118,37 +132,37 @@ func (s *configSuite) TestBasicPolicy(c *C) {
 
 	cfg, err = s.tlc.GetPolicy("quux")
 	c.Assert(err, IsNil)
-	c.Assert(cfg, DeepEquals, testPolicys["basic"])
+	c.Assert(cfg, DeepEquals, testPolicies["basic"])
 }
 
 func (s *configSuite) TestPolicyValidate(c *C) {
 	for _, key := range []string{"basic", "basic2", "nilfs"} {
-		c.Assert(testPolicys[key].Validate(), IsNil)
+		c.Assert(testPolicies[key].Validate(), IsNil)
 	}
 
 	// FIXME: ensure the default filesystem option is set when validate is called.
 	//        honestly, this both a pretty lousy way to do it and test it, we should do
 	//        something better.
-	c.Assert(testPolicys["nilfs"].FileSystems, DeepEquals, map[string]string{defaultFilesystem: "mkfs.ext4 -m0 %"})
+	c.Assert(testPolicies["nilfs"].FileSystems, DeepEquals, map[string]string{defaultFilesystem: "mkfs.ext4 -m0 %"})
 
-	c.Assert(testPolicys["untouchedwithzerosize"].Validate(), NotNil)
-	c.Assert(testPolicys["nopool"].Validate(), NotNil)
-	c.Assert(testPolicys["badsize"].Validate(), NotNil)
-	c.Assert(testPolicys["badsize2"].Validate(), NotNil)
-	_, err := testPolicys["badsize3"].DefaultVolumeOptions.ActualSize()
+	c.Assert(testPolicies["nobackend"].Validate(), NotNil)
+	c.Assert(testPolicies["untouchedwithzerosize"].Validate(), NotNil)
+	c.Assert(testPolicies["badsize"].Validate(), NotNil)
+	c.Assert(testPolicies["badsize2"].Validate(), NotNil)
+	_, err := testPolicies["badsize3"].CreateOptions.ActualSize()
 	c.Assert(err, NotNil)
 }
 
 func (s *configSuite) TestPolicyBadPublish(c *C) {
-	for _, key := range []string{"badsize", "badsize2", "badsize3", "nopool", "badsnaps"} {
-		c.Assert(s.tlc.PublishPolicy("test", testPolicys[key]), NotNil)
+	for _, key := range []string{"nobackend", "badsize", "badsize2", "badsize3", "badsnaps"} {
+		c.Assert(s.tlc.PublishPolicy("test", testPolicies[key]), NotNil)
 	}
 }
 
 func (s *configSuite) TestPolicyPublishEtcdDown(c *C) {
 	stopStartEtcd(c, func() {
 		for _, key := range []string{"basic", "basic2"} {
-			c.Assert(s.tlc.PublishPolicy("test", testPolicys[key]), NotNil)
+			c.Assert(s.tlc.PublishPolicy("test", testPolicies[key]), NotNil)
 		}
 	})
 }

--- a/config/use.go
+++ b/config/use.go
@@ -24,7 +24,7 @@ var (
 // volume, removing a volume, snapshotting a volume. These are supplied in the
 // `Reason` field as text.
 type UseMount struct {
-	Volume   *Volume
+	Volume   string
 	Hostname string
 	Reason   string
 }
@@ -33,14 +33,14 @@ type UseMount struct {
 // for snapshots this time. Taking snapshots can block certain actions such as
 // taking other snapshots or deleting snapshots.
 type UseSnapshot struct {
-	Volume *Volume
+	Volume string
 	Reason string
 }
 
 // UseLocker is an interface to locks controlled in etcd, or what we call "users".
 type UseLocker interface {
-	// GetVolume gets the *Volume for this use.
-	GetVolume() *Volume
+	// GetVolume gets the volume name for this use.
+	GetVolume() string
 	// GetReason gets the reason for this use.
 	GetReason() string
 	// Type returns the type of lock.
@@ -50,7 +50,7 @@ type UseLocker interface {
 }
 
 // GetVolume gets the *Volume for this use.
-func (um *UseMount) GetVolume() *Volume {
+func (um *UseMount) GetVolume() string {
 	return um.Volume
 }
 
@@ -70,7 +70,7 @@ func (um *UseMount) MayExist() bool {
 }
 
 // GetVolume gets the *Volume for this use.
-func (us *UseSnapshot) GetVolume() *Volume {
+func (us *UseSnapshot) GetVolume() string {
 	return us.Volume
 }
 
@@ -89,8 +89,8 @@ func (us *UseSnapshot) MayExist() bool {
 	return false
 }
 
-func (c *Client) use(typ string, vc *Volume) string {
-	return c.prefixed(rootUse, typ, vc.String())
+func (c *Client) use(typ string, vc string) string {
+	return c.prefixed(rootUse, typ, vc)
 }
 
 // PublishUse pushes the use to etcd.
@@ -152,7 +152,7 @@ func (c *Client) RemoveUse(ut UseLocker, force bool) error {
 
 // GetUse retrieves the UseMount for the given volume name.
 func (c *Client) GetUse(ut UseLocker, vc *Volume) error {
-	resp, err := c.etcdClient.Get(context.Background(), c.use(ut.Type(), vc), nil)
+	resp, err := c.etcdClient.Get(context.Background(), c.use(ut.Type(), vc.String()), nil)
 	if err != nil {
 		return err
 	}

--- a/config/use_test.go
+++ b/config/use_test.go
@@ -16,19 +16,19 @@ var testUseVolumes = map[string]*Volume{
 
 var testUseMounts = map[string]*UseMount{
 	"basic": {
-		Volume:   testUseVolumes["basic"],
+		Volume:   testUseVolumes["basic"].String(),
 		Hostname: "hostname",
 	},
 	"basic-newhost": {
-		Volume:   testUseVolumes["basic"],
+		Volume:   testUseVolumes["basic"].String(),
 		Hostname: "hostname2",
 	},
 	"basic2": {
-		Volume:   testUseVolumes["basic2"],
+		Volume:   testUseVolumes["basic2"].String(),
 		Hostname: "hostname",
 	},
 	"basic2-newhost": {
-		Volume:   testUseVolumes["basic2"],
+		Volume:   testUseVolumes["basic2"].String(),
 		Hostname: "hostname2",
 	},
 }

--- a/config/volume.go
+++ b/config/volume.go
@@ -173,18 +173,26 @@ func (c *Client) GetVolume(policy, name string) (*Volume, error) {
 		return nil, err
 	}
 
-	resp, err = c.etcdClient.Get(context.Background(), c.volume(policy, name, "runtime"), nil)
+	runtime, err := c.GetVolumeRuntime(policy, name)
 	if err != nil {
 		return nil, err
 	}
 
-	runtime := RuntimeOptions{}
-
-	if err := json.Unmarshal([]byte(resp.Node.Value), &runtime); err != nil {
-		return nil, err
-	}
+	ret.RuntimeOptions = runtime
 
 	return ret, nil
+}
+
+// GetVolumeRuntime retrieves only the runtime parameters for the volume.
+func (c *Client) GetVolumeRuntime(policy, name string) (RuntimeOptions, error) {
+	runtime := RuntimeOptions{}
+
+	resp, err := c.etcdClient.Get(context.Background(), c.volume(policy, name, "runtime"), nil)
+	if err != nil {
+		return runtime, err
+	}
+
+	return runtime, json.Unmarshal([]byte(resp.Node.Value), &runtime)
 }
 
 // RemoveVolume removes a volume from configuration.

--- a/config/volume.go
+++ b/config/volume.go
@@ -21,16 +21,16 @@ type Volume struct {
 	PolicyName     string            `json:"policy"`
 	VolumeName     string            `json:"name"`
 	DriverOptions  map[string]string `json:"driver"`
-	CreateOptions  `json:"create"`
-	RuntimeOptions `json:"runtime"`
-	Backend        string
+	CreateOptions  CreateOptions     `json:"create"`
+	RuntimeOptions RuntimeOptions    `json:"runtime"`
+	Backend        string            `json:"backend"`
 }
 
 // CreateOptions are the set of options used by volmaster during the volume
 // create operation.
 type CreateOptions struct {
-	Size       string `json:"size"`
-	FileSystem string `json:"filesystem"`
+	Size       string `json:"size" merge:"size"`
+	FileSystem string `json:"filesystem" merge:"filesystem"`
 
 	actualSize units.Base2Bytes
 }
@@ -84,7 +84,7 @@ func (c *Client) CreateVolume(rc RequestCreate) (*Volume, error) {
 		return nil, err
 	}
 
-	if err := mergeOpts(&resp.RuntimeOptions, rc.Opts); err != nil {
+	if err := mergeOpts(resp, rc.Opts); err != nil {
 		return nil, err
 	}
 

--- a/config/volume_test.go
+++ b/config/volume_test.go
@@ -99,7 +99,7 @@ func (s *configSuite) TestVolumeOptionsValidate(c *C) {
 func (s *configSuite) TestWatchVolumes(c *C) {
 	c.Assert(s.tlc.PublishPolicy("policy1", testPolicies["basic"]), IsNil)
 	volumeChan := make(chan *watch.Watch)
-	s.tlc.WatchVolumes(volumeChan)
+	s.tlc.WatchVolumeCreates(volumeChan)
 
 	vol, err := s.tlc.CreateVolume(RequestCreate{Policy: "policy1", Volume: "test"})
 	c.Assert(err, IsNil)

--- a/config/volume_test.go
+++ b/config/volume_test.go
@@ -145,10 +145,12 @@ func (s *configSuite) TestVolumeCRUD(c *C) {
 
 	for _, policy := range policyNames {
 		for _, volume := range volumeNames {
-			vcfg, err := s.tlc.CreateVolume(RequestCreate{Policy: policy, Volume: volume})
+			vcfg, err := s.tlc.CreateVolume(RequestCreate{Policy: policy, Volume: volume, Opts: map[string]string{"filesystem": ""}})
 			c.Assert(err, IsNil)
 			c.Assert(s.tlc.PublishVolume(vcfg), IsNil)
 			c.Assert(s.tlc.PublishVolume(vcfg), Equals, ErrExist)
+
+			c.Assert(vcfg.CreateOptions.FileSystem, Equals, "ext4")
 
 			defer func(policy, volume string) { c.Assert(s.tlc.RemoveVolume(policy, volume), IsNil) }(policy, volume)
 

--- a/config/volume_test.go
+++ b/config/volume_test.go
@@ -10,86 +10,94 @@ import (
 )
 
 func (s *configSuite) TestActualSize(c *C) {
-	vo := &VolumeOptions{Size: "10MB", UseSnapshots: false, Pool: "rbd"}
+	vo := &CreateOptions{Size: "10MB"}
 	actualSize, err := vo.ActualSize()
 	c.Assert(err, IsNil)
 	c.Assert(int(actualSize), Equals, 10)
 
-	vo = &VolumeOptions{Size: "1GB", UseSnapshots: false, Pool: "rbd"}
+	vo = &CreateOptions{Size: "1GB"}
 	actualSize, err = vo.ActualSize()
 	c.Assert(err, IsNil)
 	c.Assert(int(actualSize), Equals, 1024)
 
-	vo = &VolumeOptions{Size: "0", UseSnapshots: false, Pool: "rbd"}
+	vo = &CreateOptions{Size: "0"}
 	actualSize, err = vo.ActualSize()
 	c.Assert(err, IsNil)
 	c.Assert(int(actualSize), Equals, 0)
 
-	vo = &VolumeOptions{Size: "10M", UseSnapshots: false, Pool: "rbd"}
+	vo = &CreateOptions{Size: "10M"}
 	_, err = vo.ActualSize()
 	c.Assert(err, NotNil)
 
-	vo = &VolumeOptions{Size: "garbage", UseSnapshots: false, Pool: "rbd"}
+	vo = &CreateOptions{Size: "garbage"}
 	_, err = vo.ActualSize()
 	c.Assert(err, NotNil)
 }
 
 func (s *configSuite) TestVolumeValidate(c *C) {
 	vc := &Volume{
-		Options:    nil,
 		VolumeName: "foo",
 		PolicyName: "policy1",
 	}
 	c.Assert(vc.Validate(), NotNil)
 
 	vc = &Volume{
-		Options:    &VolumeOptions{Size: "10MB", UseSnapshots: false, Pool: "rbd", actualSize: 10},
-		VolumeName: "",
-		PolicyName: "policy1",
+		DriverOptions:  map[string]string{"pool": "rbd"},
+		CreateOptions:  CreateOptions{Size: "10MB", actualSize: 10},
+		RuntimeOptions: RuntimeOptions{UseSnapshots: false},
+		VolumeName:     "",
+		PolicyName:     "policy1",
 	}
 
 	c.Assert(vc.Validate(), NotNil)
 
 	vc = &Volume{
-		Options:    &VolumeOptions{Size: "10MB", UseSnapshots: false, Pool: "rbd", actualSize: 10},
-		VolumeName: "foo",
-		PolicyName: "",
+		DriverOptions:  map[string]string{"pool": "rbd"},
+		CreateOptions:  CreateOptions{Size: "10MB", actualSize: 10},
+		RuntimeOptions: RuntimeOptions{UseSnapshots: false},
+		VolumeName:     "foo",
+		PolicyName:     "",
 	}
 
 	c.Assert(vc.Validate(), NotNil)
 
 	vc = &Volume{
-		Options:    &VolumeOptions{Size: "10MB", UseSnapshots: false, Pool: "rbd", actualSize: 10},
-		VolumeName: "foo",
-		PolicyName: "policy1",
+		Backend:        "ceph",
+		DriverOptions:  map[string]string{"pool": "rbd"},
+		CreateOptions:  CreateOptions{Size: "10MB", actualSize: 10},
+		RuntimeOptions: RuntimeOptions{UseSnapshots: false},
+		VolumeName:     "foo",
+		PolicyName:     "policy1",
 	}
 
 	c.Assert(vc.Validate(), IsNil)
 }
 
 func (s *configSuite) TestVolumeOptionsValidate(c *C) {
-	opts := &VolumeOptions{}
+	opts := CreateOptions{}
 	c.Assert(opts.Validate(), NotNil)
+	opts2 := RuntimeOptions{}
+	c.Assert(opts2.Validate(), IsNil)
 
-	opts = &VolumeOptions{Size: "0"}
+	opts = CreateOptions{Size: "0"}
 	c.Assert(opts.Validate(), NotNil)
-	opts = &VolumeOptions{Size: "10MB", Pool: "rbd", actualSize: 10}
+	opts = CreateOptions{Size: "10MB", actualSize: 10}
 	c.Assert(opts.Validate(), IsNil)
 
-	opts = &VolumeOptions{Size: "10MB", UseSnapshots: true, Pool: "rbd", actualSize: 10}
-	c.Assert(opts.Validate(), NotNil)
-	opts = &VolumeOptions{Size: "10MB", UseSnapshots: true, Snapshot: SnapshotConfig{}, Pool: "rbd", actualSize: 10}
-	c.Assert(opts.Validate(), NotNil)
-	opts = &VolumeOptions{Size: "10MB", UseSnapshots: true, Snapshot: SnapshotConfig{Frequency: "10m", Keep: 0}, Pool: "rbd", actualSize: 10}
-	c.Assert(opts.Validate(), NotNil)
-	opts = &VolumeOptions{Size: "10MB", UseSnapshots: true, Snapshot: SnapshotConfig{Frequency: "", Keep: 10}, Pool: "rbd", actualSize: 10}
-	c.Assert(opts.Validate(), NotNil)
-	opts = &VolumeOptions{Size: "10MB", UseSnapshots: true, Snapshot: SnapshotConfig{Frequency: "10m", Keep: 10}, Pool: "rbd", actualSize: 10}
-	c.Assert(opts.Validate(), IsNil)
+	opts2 = RuntimeOptions{UseSnapshots: true}
+	c.Assert(opts2.Validate(), NotNil)
+	opts2 = RuntimeOptions{UseSnapshots: true, Snapshot: SnapshotConfig{}}
+	c.Assert(opts2.Validate(), NotNil)
+	opts2 = RuntimeOptions{UseSnapshots: true, Snapshot: SnapshotConfig{Frequency: "10m", Keep: 0}}
+	c.Assert(opts2.Validate(), NotNil)
+	opts2 = RuntimeOptions{UseSnapshots: true, Snapshot: SnapshotConfig{Frequency: "", Keep: 10}}
+	c.Assert(opts2.Validate(), NotNil)
+	opts2 = RuntimeOptions{UseSnapshots: true, Snapshot: SnapshotConfig{Frequency: "10m", Keep: 10}}
+	c.Assert(opts2.Validate(), IsNil)
 }
 
 func (s *configSuite) TestWatchVolumes(c *C) {
-	c.Assert(s.tlc.PublishPolicy("policy1", testPolicys["basic"]), IsNil)
+	c.Assert(s.tlc.PublishPolicy("policy1", testPolicies["basic"]), IsNil)
 	volumeChan := make(chan *watch.Watch)
 	s.tlc.WatchVolumes(volumeChan)
 
@@ -102,7 +110,9 @@ func (s *configSuite) TestWatchVolumes(c *C) {
 	volConfig := vol2.Config.(*Volume)
 	c.Assert(vol.PolicyName, Equals, volConfig.PolicyName)
 	c.Assert(vol.VolumeName, Equals, volConfig.VolumeName)
-	c.Assert(vol.Options, DeepEquals, volConfig.Options)
+	c.Assert(vol.CreateOptions, DeepEquals, volConfig.CreateOptions)
+	c.Assert(vol.RuntimeOptions, DeepEquals, volConfig.RuntimeOptions)
+	c.Assert(vol.DriverOptions, DeepEquals, volConfig.DriverOptions)
 }
 
 func (s *configSuite) TestVolumeCRUD(c *C) {
@@ -118,13 +128,10 @@ func (s *configSuite) TestVolumeCRUD(c *C) {
 
 	// populate the policies so the next few tests don't give false positives
 	for _, policy := range policyNames {
-		c.Assert(s.tlc.PublishPolicy(policy, testPolicys["basic"]), IsNil)
+		c.Assert(s.tlc.PublishPolicy(policy, testPolicies["basic"]), IsNil)
 	}
 
 	_, err = s.tlc.CreateVolume(RequestCreate{Policy: "foo", Volume: "bar", Opts: map[string]string{"quux": "derp"}})
-	c.Assert(err, NotNil)
-
-	_, err = s.tlc.CreateVolume(RequestCreate{Policy: "foo", Volume: "bar", Opts: map[string]string{"pool": ""}})
 	c.Assert(err, NotNil)
 
 	_, err = s.tlc.CreateVolume(RequestCreate{Policy: "foo", Volume: ""})
@@ -138,27 +145,22 @@ func (s *configSuite) TestVolumeCRUD(c *C) {
 
 	for _, policy := range policyNames {
 		for _, volume := range volumeNames {
-			vcfg, err := s.tlc.CreateVolume(RequestCreate{Policy: policy, Volume: volume, Opts: map[string]string{"filesystem": ""}})
+			vcfg, err := s.tlc.CreateVolume(RequestCreate{Policy: policy, Volume: volume})
 			c.Assert(err, IsNil)
 			c.Assert(s.tlc.PublishVolume(vcfg), IsNil)
 			c.Assert(s.tlc.PublishVolume(vcfg), Equals, ErrExist)
 
-			c.Assert(vcfg.Options.FileSystem, Equals, "ext4")
-
 			defer func(policy, volume string) { c.Assert(s.tlc.RemoveVolume(policy, volume), IsNil) }(policy, volume)
 
 			c.Assert(vcfg.VolumeName, Equals, volume)
-			opts := testPolicys["basic"].DefaultVolumeOptions
-			opts.Pool = "rbd"
-			c.Assert(vcfg.Options, DeepEquals, &opts)
 
 			vcfg2, err := s.tlc.GetVolume(policy, volume)
 			c.Assert(err, IsNil)
 
 			c.Assert(vcfg, DeepEquals, vcfg2)
 
-			vcfg.Options.Size = "0"
-			vcfg.Options.actualSize = 0
+			vcfg.CreateOptions.Size = "0"
+			vcfg.CreateOptions.actualSize = 0
 			c.Assert(s.tlc.PublishVolume(vcfg), NotNil)
 		}
 

--- a/config/volume_test.go
+++ b/config/volume_test.go
@@ -99,7 +99,7 @@ func (s *configSuite) TestVolumeOptionsValidate(c *C) {
 func (s *configSuite) TestWatchVolumes(c *C) {
 	c.Assert(s.tlc.PublishPolicy("policy1", testPolicies["basic"]), IsNil)
 	volumeChan := make(chan *watch.Watch)
-	s.tlc.WatchVolumeCreates(volumeChan)
+	s.tlc.WatchVolumeRuntimes(volumeChan)
 
 	vol, err := s.tlc.CreateVolume(RequestCreate{Policy: "policy1", Volume: "test"})
 	c.Assert(err, IsNil)
@@ -107,12 +107,8 @@ func (s *configSuite) TestWatchVolumes(c *C) {
 	vol2 := <-volumeChan
 	c.Assert(vol2.Key, Equals, "policy1/test")
 	c.Assert(vol2.Config, NotNil)
-	volConfig := vol2.Config.(*Volume)
-	c.Assert(vol.PolicyName, Equals, volConfig.PolicyName)
-	c.Assert(vol.VolumeName, Equals, volConfig.VolumeName)
-	c.Assert(vol.CreateOptions, DeepEquals, volConfig.CreateOptions)
-	c.Assert(vol.RuntimeOptions, DeepEquals, volConfig.RuntimeOptions)
-	c.Assert(vol.DriverOptions, DeepEquals, volConfig.DriverOptions)
+	volConfig := vol2.Config.(*RuntimeOptions)
+	c.Assert(vol.RuntimeOptions, DeepEquals, *volConfig)
 }
 
 func (s *configSuite) TestVolumeCRUD(c *C) {
@@ -181,6 +177,10 @@ func (s *configSuite) TestVolumeCRUD(c *C) {
 		sort.Strings(volumeKeys)
 
 		c.Assert(volumeNames, DeepEquals, volumeKeys)
+		for _, vol := range volumes {
+			c.Assert(vol.CreateOptions, DeepEquals, testPolicies["basic"].CreateOptions)
+			c.Assert(vol.RuntimeOptions, DeepEquals, testPolicies["basic"].RuntimeOptions)
+		}
 	}
 
 	allVols, err := s.tlc.ListAllVolumes()

--- a/lock/lock_test.go
+++ b/lock/lock_test.go
@@ -45,7 +45,7 @@ func (s *lockSuite) TestExecuteWithUseLock(c *C) {
 	vc, err := s.tlc.CreateVolume(config.RequestCreate{Policy: "policy", Volume: "foo"})
 	c.Assert(err, IsNil)
 	uc := &config.UseMount{
-		Volume:   vc,
+		Volume:   vc.String(),
 		Reason:   ReasonCreate,
 		Hostname: "mon0",
 	}
@@ -80,7 +80,7 @@ func (s *lockSuite) TestExecuteWithUseLock(c *C) {
 
 	for i := 0; i < 50; i++ {
 		uc := &config.UseMount{
-			Volume:   vc,
+			Volume:   vc.String(),
 			Reason:   ReasonCreate,
 			Hostname: fmt.Sprintf("mon%d", i+1), // doubly ensure we try to write a use lock at this point
 		}
@@ -104,13 +104,13 @@ func (s *lockSuite) TestExecuteWithMultiUseLock(c *C) {
 	vc, err := s.tlc.CreateVolume(config.RequestCreate{Policy: "policy", Volume: "foo"})
 	c.Assert(err, IsNil)
 	um := &config.UseMount{
-		Volume:   vc,
+		Volume:   vc.String(),
 		Reason:   ReasonCreate,
 		Hostname: "mon0",
 	}
 
 	us := &config.UseSnapshot{
-		Volume: vc,
+		Volume: vc.String(),
 		Reason: ReasonCreate,
 	}
 
@@ -144,7 +144,7 @@ func (s *lockSuite) TestExecuteWithMultiUseLock(c *C) {
 
 	for i := 0; i < 50; i++ {
 		uc := &config.UseMount{
-			Volume:   vc,
+			Volume:   vc.String(),
 			Reason:   ReasonCreate,
 			Hostname: fmt.Sprintf("mon%d", i), // doubly ensure we try to write a use lock at this point
 		}
@@ -157,7 +157,7 @@ func (s *lockSuite) TestExecuteWithMultiUseLock(c *C) {
 		}()
 
 		us := &config.UseSnapshot{
-			Volume: vc,
+			Volume: vc.String(),
 			Reason: ReasonCreate,
 		}
 

--- a/lock/policy.json
+++ b/lock/policy.json
@@ -1,7 +1,12 @@
 {
-  "default-options": {
-    "pool": "rbd",
-    "size": "10MB",
+  "backend": "ceph",
+  "driver": {
+    "pool": "rbd"
+  },
+  "create": {
+    "size": "10MB"
+  },
+  "runtime": {
     "snapshots": true,
     "snapshot": {
       "frequency": "30m",

--- a/storage/backend/ceph/ceph.go
+++ b/storage/backend/ceph/ceph.go
@@ -127,9 +127,7 @@ func (c *Driver) Destroy(do storage.DriverOptions) error {
 	cmd = exec.Command("rbd", "rm", do.Volume.Name, "--pool", poolName)
 	er, _ = runWithTimeout(cmd, do.Timeout)
 	if er.ExitStatus != 0 {
-		er2, _ := executor.NewCapture(exec.Command("rbd", "ls")).Run(context.Background())
-
-		return errored.Errorf("Destroying disk %q: %v (%v) %v", do.Volume.Name, er, er.Stdout, er2.Stdout)
+		return errored.Errorf("Destroying disk %q: %v (%v)", do.Volume.Name, er, er.Stdout)
 	}
 
 	return nil

--- a/systemtests/battery_test.go
+++ b/systemtests/battery_test.go
@@ -51,7 +51,9 @@ func (s *systemtestSuite) TestBatteryParallelMount(c *C) {
 
 		for x := 0; x < count; x++ {
 			go func(nodes []vagrantssh.TestbedNode, x int) {
-				c.Assert(s.createVolume("mon0", "policy1", fmt.Sprintf("test%d", x), nil), IsNil)
+				for _, node := range nodes {
+					c.Assert(s.createVolume(node.GetName(), "policy1", fmt.Sprintf("test%d", x), nil), IsNil)
+				}
 
 				contID := ""
 				var contNode *vagrantssh.TestbedNode

--- a/systemtests/integrated_test.go
+++ b/systemtests/integrated_test.go
@@ -43,22 +43,25 @@ func (s *systemtestSuite) TestIntegratedUseMountLock(c *C) {
 func (s *systemtestSuite) TestIntegratedMultiPool(c *C) {
 	defer s.mon0cmd("sudo ceph osd pool delete test test --yes-i-really-really-mean-it")
 	_, err := s.mon0cmd("sudo ceph osd pool create test 1 1")
+	c.Assert(err, IsNil)
 
-	c.Assert(s.createVolume("mon0", "policy1", "test", map[string]string{"pool": "test"}), IsNil)
+	_, err = s.uploadIntent("testpool", "testpool")
+	c.Assert(err, IsNil)
 
-	out, err := s.volcli("volume get policy1/test")
+	c.Assert(s.createVolume("mon0", "testpool", "test", nil), IsNil)
+
+	out, err := s.volcli("volume get testpool/test")
 	c.Assert(err, IsNil)
 
 	vc := &config.Volume{}
 	c.Assert(json.Unmarshal([]byte(out), vc), IsNil)
-	actualSize, err := vc.Options.ActualSize()
+	actualSize, err := vc.CreateOptions.ActualSize()
 	c.Assert(err, IsNil)
 	c.Assert(actualSize, Equals, uint64(10))
 }
 
 func (s *systemtestSuite) TestIntegratedDriverOptions(c *C) {
 	opts := map[string]string{
-		"size":                "200MB",
 		"snapshots":           "true",
 		"snapshots.frequency": "100m",
 		"snapshots.keep":      "20",
@@ -73,56 +76,8 @@ func (s *systemtestSuite) TestIntegratedDriverOptions(c *C) {
 
 	vc := &config.Volume{}
 	c.Assert(json.Unmarshal([]byte(out), vc), IsNil)
-	actualSize, err := vc.Options.ActualSize()
-	c.Assert(err, IsNil)
-	c.Assert(actualSize, Equals, uint64(200))
-	c.Assert(vc.Options.Snapshot.Frequency, Equals, "100m")
-	c.Assert(vc.Options.Snapshot.Keep, Equals, uint(20))
-}
-
-func (s *systemtestSuite) TestIntegratedMultipleFileSystems(c *C) {
-	_, err := s.uploadIntent("policy2", "fs")
-	c.Assert(err, IsNil)
-
-	opts := map[string]string{
-		"size": "1GB",
-	}
-
-	c.Assert(s.createVolume("mon0", "policy2", "test", opts), IsNil)
-	c.Assert(s.vagrant.GetNode("mon0").RunCommand("docker run -d -v policy2/test:/mnt alpine sleep 10m"), IsNil)
-
-	out, err := s.vagrant.GetNode("mon0").RunCommandWithOutput("mount -l -t btrfs")
-	c.Assert(err, IsNil)
-
-	lines := strings.Split(out, "\n")
-	pass := false
-	for _, line := range lines {
-		// cheat.
-		if strings.Contains(line, "/dev/rbd") {
-			pass = true
-			break
-		}
-	}
-
-	c.Assert(pass, Equals, true)
-	c.Assert(s.createVolume("mon0", "policy2", "testext4", map[string]string{"filesystem": "ext4"}), IsNil)
-
-	c.Assert(s.vagrant.GetNode("mon0").RunCommand("docker run -d -v policy2/testext4:/mnt alpine sleep 10m"), IsNil)
-
-	out, err = s.vagrant.GetNode("mon0").RunCommandWithOutput("mount -l -t ext4")
-	c.Assert(err, IsNil)
-
-	lines = strings.Split(out, "\n")
-	pass = false
-	for _, line := range lines {
-		// cheat.
-		if strings.Contains(line, "/dev/rbd") {
-			pass = true
-			break
-		}
-	}
-
-	c.Assert(pass, Equals, true)
+	c.Assert(vc.RuntimeOptions.Snapshot.Frequency, Equals, "100m")
+	c.Assert(vc.RuntimeOptions.Snapshot.Keep, Equals, uint(20))
 }
 
 func (s *systemtestSuite) TestIntegratedRateLimiting(c *C) {

--- a/systemtests/testdata/fastsnap.json
+++ b/systemtests/testdata/fastsnap.json
@@ -1,7 +1,12 @@
 { 
-  "default-options": {
-    "pool": "rbd",
-    "size": "10MB",
+  "backend": "ceph",
+  "driver": {
+    "pool": "rbd"
+  },
+  "create": {
+    "size": "10MB"
+  },
+  "runtime": {
     "snapshots": true,
     "snapshot": {
       "frequency": "2s",

--- a/systemtests/testdata/fs.json
+++ b/systemtests/testdata/fs.json
@@ -1,13 +1,18 @@
 { 
-  "default-options": {
-    "pool": "rbd",
+  "backend": "ceph",
+  "driver": {
+    "pool": "rbd"
+  },
+  "create": {
     "size": "10MB",
+    "filesystem": "btrfs"
+  },
+  "runtime": {
     "snapshots": true,
     "snapshot": {
       "frequency": "30m",
       "keep": 20
-    },
-    "filesystem": "btrfs"
+    }
   },
   "filesystems": {
     "ext4": "mkfs.ext4 -m0 %",

--- a/systemtests/testdata/iops1.json
+++ b/systemtests/testdata/iops1.json
@@ -1,0 +1,8 @@
+{
+  "rate-limit": {
+    "write-bps": 1000000,
+    "write-iops": 1000,
+    "read-bps": 10,
+    "read-iops": 1200
+  }
+}

--- a/systemtests/testdata/nosnap.json
+++ b/systemtests/testdata/nosnap.json
@@ -1,7 +1,12 @@
 { 
-  "default-options": {
-    "pool": "rbd",
-    "size": "10MB",
+  "backend": "ceph",
+  "driver": {
+    "pool": "rbd"
+  },
+  "create": {
+    "size": "10MB"
+  },
+  "runtime": {
     "snapshots": false
   }
 }

--- a/systemtests/testdata/nulldriver.json
+++ b/systemtests/testdata/nulldriver.json
@@ -1,12 +1,16 @@
 { 
-  "default-options": {
-    "pool": "rbd",
-    "size": "10MB",
+  "backend": "null",
+  "driver": {
+    "pool": "rbd"
+  },
+  "create": {
+    "size": "10MB"
+  },
+  "runtime": {
     "snapshots": true,
     "snapshot": {
       "frequency": "30m",
       "keep": 20
-    },
-    "backend" : "null"
+    }
   }
 }

--- a/systemtests/testdata/policy1.json
+++ b/systemtests/testdata/policy1.json
@@ -1,7 +1,12 @@
 { 
-  "default-options": {
-    "pool": "rbd",
-    "size": "10MB",
+  "backend": "ceph",
+  "driver": {
+    "pool": "rbd"
+  },
+  "create": {
+    "size": "10MB"
+  },
+  "runtime": {
     "snapshots": true,
     "snapshot": {
       "frequency": "30m",

--- a/systemtests/testdata/runtime1.json
+++ b/systemtests/testdata/runtime1.json
@@ -1,0 +1,7 @@
+{
+  "snapshots": true,
+  "snapshot": {
+    "frequency": "1m",
+    "keep": 15
+  }
+}

--- a/systemtests/testdata/testpool.json
+++ b/systemtests/testdata/testpool.json
@@ -1,16 +1,16 @@
-{ 
+{
   "backend": "ceph",
   "driver": {
-    "pool": "rbd"
+    "pool": "test"
   },
   "create": {
-    "size": "100MB"
+    "size": "10MB"
   },
   "runtime": {
     "snapshots": true,
     "snapshot": {
-      "frequency": "1m",
-      "keep": 10
+      "frequency": "30m",
+      "keep": 20
     }
   }
 }

--- a/systemtests/volcli_test.go
+++ b/systemtests/volcli_test.go
@@ -217,9 +217,9 @@ func (s *systemtestSuite) TestVolCLIUse(c *C) {
 	_, err = s.volcli("volume create policy1/foo")
 	c.Assert(err, IsNil)
 
-	// ensure that double-create does nothing (for now, at least)
+	// ensure that double-create errors
 	_, err = s.volcli("volume create policy1/foo")
-	c.Assert(err, IsNil)
+	c.Assert(err, NotNil)
 
 	_, err = s.volcli("volume get policy1/foo")
 	c.Assert(err, IsNil)

--- a/systemtests/volcli_test.go
+++ b/systemtests/volcli_test.go
@@ -242,4 +242,12 @@ func (s *systemtestSuite) TestVolCLIRuntime(c *C) {
 	c.Assert(json.Unmarshal([]byte(volcliOut), volume), IsNil)
 
 	c.Assert(volume.RuntimeOptions, DeepEquals, runtimeOptions)
+	c.Assert(volume.RuntimeOptions.Snapshot.Keep, Equals, uint(20))
+
+	_, err = s.volcli("volume runtime upload policy1/foo < /testdata/runtime1.json")
+	volcliOut, err = s.volcli("volume get policy1/foo")
+	c.Assert(err, IsNil)
+	volume = &config.Volume{}
+	c.Assert(json.Unmarshal([]byte(volcliOut), volume), IsNil)
+	c.Assert(volume.RuntimeOptions.Snapshot.Keep, Equals, uint(15))
 }

--- a/systemtests/volcli_test.go
+++ b/systemtests/volcli_test.go
@@ -228,3 +228,18 @@ func (s *systemtestSuite) TestVolCLIUse(c *C) {
 	// instead, which would happen above.
 	c.Assert(out, Equals, "")
 }
+
+func (s *systemtestSuite) TestVolCLIRuntime(c *C) {
+	c.Assert(s.createVolume("mon0", "policy1", "foo", nil), IsNil)
+	volcliOut, err := s.volcli("volume runtime get policy1/foo")
+	c.Assert(err, IsNil)
+	runtimeOptions := config.RuntimeOptions{}
+	c.Assert(json.Unmarshal([]byte(volcliOut), &runtimeOptions), IsNil)
+
+	volcliOut, err = s.volcli("volume get policy1/foo")
+	c.Assert(err, IsNil)
+	volume := &config.Volume{}
+	c.Assert(json.Unmarshal([]byte(volcliOut), volume), IsNil)
+
+	c.Assert(volume.RuntimeOptions, DeepEquals, runtimeOptions)
+}

--- a/systemtests/volcli_test.go
+++ b/systemtests/volcli_test.go
@@ -115,14 +115,14 @@ func (s *systemtestSuite) TestVolCLIVolume(c *C) {
 
 	c.Assert(json.Unmarshal([]byte(out), cfg), IsNil)
 
-	cfg.Options.FileSystem = "ext4"
+	cfg.CreateOptions.FileSystem = "ext4"
 
 	policy1, err := s.readIntent("testdata/policy1.json")
 	c.Assert(err, IsNil)
 
-	policy1.DefaultVolumeOptions.FileSystem = "ext4"
+	policy1.CreateOptions.FileSystem = "ext4"
 
-	c.Assert(policy1.DefaultVolumeOptions, DeepEquals, *cfg.Options)
+	c.Assert(policy1.CreateOptions, DeepEquals, cfg.CreateOptions)
 
 	_, err = s.volcli("volume remove policy1/foo")
 	c.Assert(err, IsNil)
@@ -144,12 +144,13 @@ func (s *systemtestSuite) TestVolCLIVolume(c *C) {
 
 	cfg = &config.Volume{}
 	c.Assert(json.Unmarshal([]byte(out), cfg), IsNil)
-	cfg.Options.FileSystem = "ext4"
+	cfg.CreateOptions.FileSystem = "ext4"
 	policy1, err = s.readIntent("testdata/policy1.json")
 	c.Assert(err, IsNil)
-	policy1.DefaultVolumeOptions.FileSystem = "ext4"
-	policy1.DefaultVolumeOptions.UseSnapshots = false
-	c.Assert(policy1.DefaultVolumeOptions, DeepEquals, *cfg.Options)
+	policy1.CreateOptions.FileSystem = "ext4"
+	policy1.RuntimeOptions.UseSnapshots = false
+	c.Assert(policy1.CreateOptions, DeepEquals, cfg.CreateOptions)
+	c.Assert(policy1.RuntimeOptions, DeepEquals, cfg.RuntimeOptions)
 }
 
 func (s *systemtestSuite) TestVolCLIVolumePolicyUpdate(c *C) {

--- a/systemtests/volume_test.go
+++ b/systemtests/volume_test.go
@@ -67,14 +67,16 @@ func (s *systemtestSuite) TestVolumeMultiPolicyCreate(c *C) {
 	c.Assert(err, NotNil)
 }
 
-func (s *systemtestSuite) TestVolumeParallelCreate(c *C) {
-	c.Assert(s.vagrant.IterateNodes(func(node vagrantssh.TestbedNode) error {
-		return node.RunCommand("docker volume create -d volplugin --name policy1/test")
-	}), IsNil)
+func (s *systemtestSuite) TestVolumeMultiCreateThroughDocker(c *C) {
+	c.Assert(s.createVolume("mon0", "policy1", "test", nil), IsNil)
 
 	out, err := s.vagrant.GetNode("mon0").RunCommandWithOutput("sudo rbd ls")
 	c.Assert(err, IsNil)
 	c.Assert(strings.TrimSpace(out), Equals, "policy1.test")
+
+	c.Assert(s.vagrant.IterateNodes(func(node vagrantssh.TestbedNode) error {
+		return node.RunCommand("docker volume create -d volplugin --name policy1/test")
+	}), IsNil)
 
 	c.Assert(s.vagrant.IterateNodes(func(node vagrantssh.TestbedNode) error {
 		return node.RunCommand("docker volume rm policy1/test")

--- a/systemtests/volume_test.go
+++ b/systemtests/volume_test.go
@@ -67,28 +67,6 @@ func (s *systemtestSuite) TestVolumeMultiPolicyCreate(c *C) {
 	c.Assert(err, NotNil)
 }
 
-func (s *systemtestSuite) TestVolumeEphemeral(c *C) {
-	c.Assert(s.createVolume("mon0", "policy1", "test", map[string]string{"ephemeral": "true"}), IsNil)
-	out, err := s.vagrant.GetNode("mon0").RunCommandWithOutput("sudo rbd ls")
-	c.Assert(err, IsNil)
-	c.Assert(strings.TrimSpace(out), Equals, "policy1.test")
-
-	c.Assert(s.vagrant.GetNode("mon0").RunCommand("docker volume rm policy1/test"), IsNil)
-	out, err = s.vagrant.GetNode("mon0").RunCommandWithOutput("sudo rbd ls")
-	c.Assert(err, IsNil)
-	c.Assert(strings.TrimSpace(out), Not(Equals), "policy1.test")
-
-	c.Assert(s.createVolume("mon0", "policy1", "test", map[string]string{"ephemeral": "false"}), IsNil)
-	out, err = s.vagrant.GetNode("mon0").RunCommandWithOutput("sudo rbd ls")
-	c.Assert(err, IsNil)
-	c.Assert(strings.TrimSpace(out), Equals, "policy1.test")
-
-	c.Assert(s.vagrant.GetNode("mon0").RunCommand("docker volume rm policy1/test"), IsNil)
-	out, err = s.vagrant.GetNode("mon0").RunCommandWithOutput("sudo rbd ls")
-	c.Assert(err, IsNil)
-	c.Assert(strings.TrimSpace(out), Equals, "policy1.test")
-}
-
 func (s *systemtestSuite) TestVolumeParallelCreate(c *C) {
 	c.Assert(s.vagrant.IterateNodes(func(node vagrantssh.TestbedNode) error {
 		return node.RunCommand("docker volume create -d volplugin --name policy1/test")

--- a/volcli/commands.go
+++ b/volcli/commands.go
@@ -170,6 +170,13 @@ var Commands = []cli.Command{
 						Usage:       "Get runtime configuration",
 						Action:      VolumeRuntimeGet,
 					},
+					{
+						Name:        "upload",
+						ArgsUsage:   "[policy name]/[volume name]",
+						Description: "Upload runtime configuration",
+						Usage:       "Upload runtime configuration",
+						Action:      VolumeRuntimeUpload,
+					},
 				},
 			},
 		},

--- a/volcli/commands.go
+++ b/volcli/commands.go
@@ -158,6 +158,20 @@ var Commands = []cli.Command{
 					},
 				},
 			},
+			{
+				Name:        "runtime",
+				Description: "Runtime configuration management",
+				Usage:       "Runtime configuration management",
+				Subcommands: []cli.Command{
+					{
+						Name:        "get",
+						ArgsUsage:   "[policy name]/[volume name]",
+						Description: "Get runtime configuration",
+						Usage:       "Get runtime configuration",
+						Action:      VolumeRuntimeGet,
+					},
+				},
+			},
 		},
 	},
 	{

--- a/volcli/commands.go
+++ b/volcli/commands.go
@@ -168,6 +168,7 @@ var Commands = []cli.Command{
 						ArgsUsage:   "[policy name]/[volume name]",
 						Description: "Get runtime configuration",
 						Usage:       "Get runtime configuration",
+						Flags:       VolmasterFlags,
 						Action:      VolumeRuntimeGet,
 					},
 					{

--- a/volcli/volcli.go
+++ b/volcli/volcli.go
@@ -100,7 +100,7 @@ func globalGet(ctx *cli.Context) (bool, error) {
 
 	// rebuild and divide the contents so they are cast out of their internal
 	// representation.
-	content, err := json.Marshal(config.DivideGlobalParameters(global))
+	content, err := ppJSON(config.DivideGlobalParameters(global))
 	if err != nil {
 		return false, err
 	}

--- a/volcli/volcli.go
+++ b/volcli/volcli.go
@@ -653,11 +653,11 @@ func useTheForce(ctx *cli.Context) (bool, error) {
 		VolumeName: volume,
 	}
 
-	if err := cfg.RemoveUse(&config.UseMount{Volume: vc}, true); err != nil {
+	if err := cfg.RemoveUse(&config.UseMount{Volume: vc.String()}, true); err != nil {
 		fmt.Fprintf(os.Stderr, "Trouble removing mount lock (may be harmless) for %q: %v", vc, err)
 	}
 
-	if err := cfg.RemoveUse(&config.UseSnapshot{Volume: vc}, true); err != nil {
+	if err := cfg.RemoveUse(&config.UseSnapshot{Volume: vc.String()}, true); err != nil {
 		fmt.Fprintf(os.Stderr, "Trouble removing snapshot lock (may be harmless) for %q: %v", vc, err)
 	}
 
@@ -695,13 +695,13 @@ func useExec(ctx *cli.Context) (bool, error) {
 	}
 
 	um := &config.UseMount{
-		Volume:   vc,
+		Volume:   vc.String(),
 		Reason:   lock.ReasonMaintenance,
 		Hostname: host,
 	}
 
 	us := &config.UseSnapshot{
-		Volume: vc,
+		Volume: vc.String(),
 		Reason: lock.ReasonMaintenance,
 	}
 

--- a/volcli/volcli.go
+++ b/volcli/volcli.go
@@ -733,3 +733,38 @@ func useExec(ctx *cli.Context) (bool, error) {
 
 	return false, err
 }
+
+// VolumeRuntimeGet retrieves the runtime configuration for a volume.
+func VolumeRuntimeGet(ctx *cli.Context) {
+	execCliAndExit(ctx, volumeRuntimeGet)
+}
+
+func volumeRuntimeGet(ctx *cli.Context) (bool, error) {
+	if len(ctx.Args()) != 1 {
+		return true, errorInvalidArgCount(len(ctx.Args()), 1, ctx.Args())
+	}
+
+	policy, volume, err := splitVolume(ctx)
+	if err != nil {
+		return true, err
+	}
+
+	cfg, err := config.NewClient(ctx.GlobalString("prefix"), ctx.GlobalStringSlice("etcd"))
+	if err != nil {
+		return false, err
+	}
+
+	runtime, err := cfg.GetVolumeRuntime(policy, volume)
+	if err != nil {
+		return false, err
+	}
+
+	content, err := ppJSON(runtime)
+	if err != nil {
+		return false, err
+	}
+
+	fmt.Println(string(content))
+
+	return false, nil
+}

--- a/volmaster/daemon.go
+++ b/volmaster/daemon.go
@@ -165,10 +165,8 @@ func (d *DaemonConfig) handleSnapshotList(w http.ResponseWriter, r *http.Request
 
 	do := storage.DriverOptions{
 		Volume: storage.Volume{
-			Name: intName,
-			Params: storage.Params{
-				"pool": volConfig.Options.Pool,
-			},
+			Name:   intName,
+			Params: volConfig.DriverOptions,
 		},
 		Timeout: d.Global.Timeout,
 	}
@@ -238,10 +236,8 @@ func (d *DaemonConfig) handleCopy(w http.ResponseWriter, r *http.Request) {
 
 	do := storage.DriverOptions{
 		Volume: storage.Volume{
-			Name: intName,
-			Params: storage.Params{
-				"pool": volConfig.Options.Pool,
-			},
+			Name:   intName,
+			Params: volConfig.DriverOptions,
 		},
 		Timeout: d.Global.Timeout,
 	}
@@ -328,7 +324,7 @@ func (d *DaemonConfig) handleList(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		driver, err := backend.NewDriver(volConfig.Options.Backend, d.Global.MountPath)
+		driver, err := backend.NewDriver(volConfig.Backend, d.Global.MountPath)
 		if err != nil {
 			httpError(w, "Initializing driver", err)
 			return
@@ -342,10 +338,8 @@ func (d *DaemonConfig) handleList(w http.ResponseWriter, r *http.Request) {
 
 		do := storage.DriverOptions{
 			Volume: storage.Volume{
-				Name: intName,
-				Params: storage.Params{
-					"pool": volConfig.Options.Pool,
-				},
+				Name:   intName,
+				Params: volConfig.DriverOptions,
 			},
 			Timeout: d.Global.Timeout,
 		}
@@ -378,7 +372,7 @@ func (d *DaemonConfig) handleGet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	driver, err := backend.NewDriver(volConfig.Options.Backend, d.Global.MountPath)
+	driver, err := backend.NewDriver(volConfig.Backend, d.Global.MountPath)
 	if err != nil {
 		httpError(w, "Initializing backend", err)
 		return
@@ -392,10 +386,8 @@ func (d *DaemonConfig) handleGet(w http.ResponseWriter, r *http.Request) {
 
 	do := storage.DriverOptions{
 		Volume: storage.Volume{
-			Name: intName,
-			Params: storage.Params{
-				"pool": volConfig.Options.Pool,
-			},
+			Name:   intName,
+			Params: volConfig.DriverOptions,
 		},
 		Timeout: d.Global.Timeout,
 	}

--- a/volmaster/daemon.go
+++ b/volmaster/daemon.go
@@ -610,10 +610,7 @@ func (d *DaemonConfig) handleCreate(w http.ResponseWriter, r *http.Request) {
 
 	err = lock.NewDriver(d.Config).ExecuteWithMultiUseLock([]config.UseLocker{uc, snapUC}, true, d.Global.Timeout, func(ld *lock.Driver, ucs []config.UseLocker) error {
 		do, err := d.createVolume(policy, volConfig, d.Global.Timeout)
-		if err == storage.ErrVolumeExist {
-			log.Errorf("Volume %v exists, cleaning up", volConfig)
-			return nil
-		} else if err != nil {
+		if err != nil {
 			return errored.Errorf("Creating volume").Combine(err)
 		}
 

--- a/volmaster/daemon.go
+++ b/volmaster/daemon.go
@@ -285,24 +285,24 @@ func (d *DaemonConfig) handleCopy(w http.ResponseWriter, r *http.Request) {
 	}
 
 	uc := &config.UseMount{
-		Volume:   volConfig,
+		Volume:   volConfig.String(),
 		Reason:   lock.ReasonCopy,
 		Hostname: host,
 	}
 
 	snapUC := &config.UseSnapshot{
-		Volume: volConfig,
+		Volume: volConfig.String(),
 		Reason: lock.ReasonCopy,
 	}
 
 	newUC := &config.UseMount{
-		Volume:   newVolConfig,
+		Volume:   newVolConfig.String(),
 		Reason:   lock.ReasonCopy,
 		Hostname: host,
 	}
 
 	newSnapUC := &config.UseSnapshot{
-		Volume: newVolConfig,
+		Volume: newVolConfig.String(),
 		Reason: lock.ReasonCopy,
 	}
 
@@ -448,13 +448,13 @@ func (d *DaemonConfig) handleRemove(w http.ResponseWriter, r *http.Request) {
 	}
 
 	uc := &config.UseMount{
-		Volume:   vc,
+		Volume:   vc.String(),
 		Reason:   lock.ReasonRemove,
 		Hostname: hostname,
 	}
 
 	snapUC := &config.UseSnapshot{
-		Volume: vc,
+		Volume: vc.String(),
 		Reason: lock.ReasonRemove,
 	}
 
@@ -520,7 +520,13 @@ func (d *DaemonConfig) handleMountReport(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	if _, err := d.Config.GetVolume(req.Volume.PolicyName, req.Volume.VolumeName); err != nil {
+	parts := strings.SplitN(req.Volume, "/", 2)
+	if len(parts) < 2 || parts[0] == "" || parts[1] == "" {
+		httpError(w, "Invalid volume name", err)
+		return
+	}
+
+	if _, err := d.Config.GetVolume(parts[0], parts[1]); err != nil {
 		httpError(w, "Cannot refresh mount information: volume no longer exists", err)
 		w.WriteHeader(404)
 		return
@@ -598,13 +604,13 @@ func (d *DaemonConfig) handleCreate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	uc := &config.UseMount{
-		Volume:   volConfig,
+		Volume:   volConfig.String(),
 		Reason:   lock.ReasonCreate,
 		Hostname: hostname,
 	}
 
 	snapUC := &config.UseSnapshot{
-		Volume: volConfig,
+		Volume: volConfig.String(),
 		Reason: lock.ReasonCreate,
 	}
 

--- a/volmaster/utils.go
+++ b/volmaster/utils.go
@@ -57,7 +57,7 @@ func unmarshalUseMount(r *http.Request) (*config.UseMount, error) {
 		return cfg, err
 	}
 
-	if cfg.Volume == nil {
+	if cfg.Volume == "" || cfg.Volume == "/" {
 		return cfg, errors.New("volume was blank")
 	}
 

--- a/volplugin/cgroup.go
+++ b/volplugin/cgroup.go
@@ -20,12 +20,12 @@ func makeLimit(mc *storage.Mount, limit uint64) []byte {
 	return []byte(fmt.Sprintf("%d:%d %d\n", mc.DevMajor, mc.DevMinor, limit))
 }
 
-func applyCGroupRateLimit(vc *config.Volume, mc *storage.Mount) error {
+func applyCGroupRateLimit(ro config.RuntimeOptions, mc *storage.Mount) error {
 	opMap := map[string]uint64{
-		writeIOPSFile: uint64(vc.RuntimeOptions.RateLimit.WriteIOPS),
-		readIOPSFile:  uint64(vc.RuntimeOptions.RateLimit.ReadIOPS),
-		writeBPSFile:  vc.RuntimeOptions.RateLimit.WriteBPS,
-		readBPSFile:   vc.RuntimeOptions.RateLimit.ReadBPS,
+		writeIOPSFile: uint64(ro.RateLimit.WriteIOPS),
+		readIOPSFile:  uint64(ro.RateLimit.ReadIOPS),
+		writeBPSFile:  ro.RateLimit.WriteBPS,
+		readBPSFile:   ro.RateLimit.ReadBPS,
 	}
 
 	for fn, val := range opMap {

--- a/volplugin/cgroup.go
+++ b/volplugin/cgroup.go
@@ -22,10 +22,10 @@ func makeLimit(mc *storage.Mount, limit uint64) []byte {
 
 func applyCGroupRateLimit(vc *config.Volume, mc *storage.Mount) error {
 	opMap := map[string]uint64{
-		writeIOPSFile: uint64(vc.Options.RateLimit.WriteIOPS),
-		readIOPSFile:  uint64(vc.Options.RateLimit.ReadIOPS),
-		writeBPSFile:  vc.Options.RateLimit.WriteBPS,
-		readBPSFile:   vc.Options.RateLimit.ReadBPS,
+		writeIOPSFile: uint64(vc.RuntimeOptions.RateLimit.WriteIOPS),
+		readIOPSFile:  uint64(vc.RuntimeOptions.RateLimit.ReadIOPS),
+		writeBPSFile:  vc.RuntimeOptions.RateLimit.WriteBPS,
+		readBPSFile:   vc.RuntimeOptions.RateLimit.ReadBPS,
 	}
 
 	for fn, val := range opMap {

--- a/volplugin/handlers.go
+++ b/volplugin/handlers.go
@@ -148,14 +148,7 @@ func (dc *DaemonConfig) remove(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if vc.Options.Ephemeral {
-		if err := dc.requestRemove(uc.Policy, uc.Name); err != nil {
-			httpError(w, "Removing ephemeral volume", err)
-			return
-		}
-	}
-
-	driver, err := backend.NewDriver(vc.Options.Backend, dc.Global.MountPath)
+	driver, err := backend.NewDriver(vc.Backend, dc.Global.MountPath)
 	if err != nil {
 		httpError(w, fmt.Sprintf("loading driver"), err)
 		return
@@ -168,10 +161,8 @@ func (dc *DaemonConfig) remove(w http.ResponseWriter, r *http.Request) {
 
 	do := storage.DriverOptions{
 		Volume: storage.Volume{
-			Name: name,
-			Params: storage.Params{
-				"pool": vc.Options.Pool,
-			},
+			Name:   name,
+			Params: vc.DriverOptions,
 		},
 		Timeout: dc.Global.Timeout,
 	}
@@ -207,7 +198,7 @@ func (dc *DaemonConfig) getPath(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	driver, err := backend.NewDriver(volConfig.Options.Backend, dc.Global.MountPath)
+	driver, err := backend.NewDriver(volConfig.Backend, dc.Global.MountPath)
 	if err != nil {
 		httpError(w, fmt.Sprintf("loading driver"), err)
 		return
@@ -220,10 +211,8 @@ func (dc *DaemonConfig) getPath(w http.ResponseWriter, r *http.Request) {
 
 	do := storage.DriverOptions{
 		Volume: storage.Volume{
-			Name: name,
-			Params: storage.Params{
-				"pool": volConfig.Options.Pool,
-			},
+			Name:   name,
+			Params: volConfig.DriverOptions,
 		},
 		Timeout: dc.Global.Timeout,
 	}
@@ -246,7 +235,7 @@ func (dc *DaemonConfig) mount(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	driver, err := backend.NewDriver(volConfig.Options.Backend, dc.Global.MountPath)
+	driver, err := backend.NewDriver(volConfig.Backend, dc.Global.MountPath)
 	if err != nil {
 		httpError(w, fmt.Sprintf("loading driver"), err)
 		return
@@ -258,7 +247,7 @@ func (dc *DaemonConfig) mount(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	actualSize, err := volConfig.Options.ActualSize()
+	actualSize, err := volConfig.CreateOptions.ActualSize()
 	if err != nil {
 		httpError(w, "Computing size of volume", err)
 		return
@@ -266,14 +255,12 @@ func (dc *DaemonConfig) mount(w http.ResponseWriter, r *http.Request) {
 
 	driverOpts := storage.DriverOptions{
 		Volume: storage.Volume{
-			Name: intName,
-			Size: actualSize,
-			Params: storage.Params{
-				"pool": volConfig.Options.Pool,
-			},
+			Name:   intName,
+			Size:   actualSize,
+			Params: volConfig.DriverOptions,
 		},
 		FSOptions: storage.FSOptions{
-			Type: volConfig.Options.FileSystem,
+			Type: volConfig.CreateOptions.FileSystem,
 		},
 		Timeout: dc.Global.Timeout,
 	}
@@ -337,7 +324,7 @@ func (dc *DaemonConfig) unmount(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	driver, err := backend.NewDriver(volConfig.Options.Backend, dc.Global.MountPath)
+	driver, err := backend.NewDriver(volConfig.Backend, dc.Global.MountPath)
 	if err != nil {
 		httpError(w, fmt.Sprintf("loading driver"), err)
 		return
@@ -351,10 +338,8 @@ func (dc *DaemonConfig) unmount(w http.ResponseWriter, r *http.Request) {
 
 	driverOpts := storage.DriverOptions{
 		Volume: storage.Volume{
-			Name: intName,
-			Params: storage.Params{
-				"pool": volConfig.Options.Pool,
-			},
+			Name:   intName,
+			Params: volConfig.DriverOptions,
 		},
 		Timeout: dc.Global.Timeout,
 	}

--- a/volplugin/handlers.go
+++ b/volplugin/handlers.go
@@ -10,8 +10,6 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/contiv/errored"
 	"github.com/contiv/volplugin/config"
-	"github.com/contiv/volplugin/storage"
-	"github.com/contiv/volplugin/storage/backend"
 	"github.com/docker/docker/pkg/plugins"
 )
 
@@ -136,35 +134,16 @@ func (dc *DaemonConfig) list(w http.ResponseWriter, r *http.Request) {
 	io.Copy(w, resp.Body)
 }
 
-func (dc *DaemonConfig) remove(w http.ResponseWriter, r *http.Request) {
+func (dc *DaemonConfig) getPath(w http.ResponseWriter, r *http.Request) {
 	uc, err := unmarshalAndCheck(w, r)
 	if err != nil {
 		return
 	}
 
-	vc, err := dc.requestVolume(uc.Policy, uc.Name)
+	driver, _, do, err := dc.structsVolumeName(uc)
 	if err != nil {
-		httpError(w, "Getting volume properties", err)
+		httpError(w, "Configuring request", err)
 		return
-	}
-
-	driver, err := backend.NewDriver(vc.Backend, dc.Global.MountPath)
-	if err != nil {
-		httpError(w, fmt.Sprintf("loading driver"), err)
-		return
-	}
-
-	name, err := driver.InternalName(uc.Request.Name)
-	if err != nil {
-		httpError(w, fmt.Sprintf("Removing volume %q", uc.Request.Name), err)
-	}
-
-	do := storage.DriverOptions{
-		Volume: storage.Volume{
-			Name:   name,
-			Params: vc.DriverOptions,
-		},
-		Timeout: dc.Global.Timeout,
 	}
 
 	writeResponse(w, r, &VolumeResponse{Mountpoint: driver.MountPath(do), Err: ""})
@@ -184,101 +163,32 @@ func (dc *DaemonConfig) create(w http.ResponseWriter, r *http.Request) {
 	writeResponse(w, r, &VolumeResponse{Mountpoint: "", Err: ""})
 }
 
-func (dc *DaemonConfig) getPath(w http.ResponseWriter, r *http.Request) {
-	uc, err := unmarshalAndCheck(w, r)
-	if err != nil {
-		return
-	}
-
-	log.Infof("Returning mount path to docker for volume: %q", uc.Request.Name)
-
-	volConfig, err := dc.requestVolume(uc.Policy, uc.Name)
-	if err != nil {
-		httpError(w, "Requesting policy configuration", err)
-		return
-	}
-
-	driver, err := backend.NewDriver(volConfig.Backend, dc.Global.MountPath)
-	if err != nil {
-		httpError(w, fmt.Sprintf("loading driver"), err)
-		return
-	}
-
-	name, err := driver.InternalName(uc.Request.Name)
-	if err != nil {
-		httpError(w, fmt.Sprintf("Removing volume %q", uc.Request.Name), err)
-	}
-
-	do := storage.DriverOptions{
-		Volume: storage.Volume{
-			Name:   name,
-			Params: volConfig.DriverOptions,
-		},
-		Timeout: dc.Global.Timeout,
-	}
-
-	// FIXME need to ensure that the mount exists before returning to docker
-	writeResponse(w, r, &VolumeResponse{Mountpoint: driver.MountPath(do)})
-}
-
 func (dc *DaemonConfig) mount(w http.ResponseWriter, r *http.Request) {
 	uc, err := unmarshalAndCheck(w, r)
 	if err != nil {
 		return
 	}
 
+	driver, volConfig, driverOpts, err := dc.structsVolumeName(uc)
+	if err != nil {
+		httpError(w, "Configuring request", err)
+		return
+	}
+
 	log.Infof("Mounting volume %q", uc.Request.Name)
-
-	volConfig, err := dc.requestVolume(uc.Policy, uc.Name)
-	if err != nil {
-		httpError(w, "Could not determine policy configuration", err)
-		return
-	}
-
-	driver, err := backend.NewDriver(volConfig.Backend, dc.Global.MountPath)
-	if err != nil {
-		httpError(w, fmt.Sprintf("loading driver"), err)
-		return
-	}
-
-	intName, err := driver.InternalName(uc.Request.Name)
-	if err != nil {
-		httpError(w, fmt.Sprintf("Volume %q does not satisfy name requirements", uc.Request.Name), err)
-		return
-	}
-
-	actualSize, err := volConfig.CreateOptions.ActualSize()
-	if err != nil {
-		httpError(w, "Computing size of volume", err)
-		return
-	}
-
-	driverOpts := storage.DriverOptions{
-		Volume: storage.Volume{
-			Name:   intName,
-			Size:   actualSize,
-			Params: volConfig.DriverOptions,
-		},
-		FSOptions: storage.FSOptions{
-			Type: volConfig.CreateOptions.FileSystem,
-		},
-		Timeout: dc.Global.Timeout,
-	}
 
 	// if we're mounted already on this host, the mount publish will succeed and
 	// we will have two mounts, which will cause trouble at unmount time.
 
-	mounts, err := driver.Mounted(dc.Global.Timeout)
+	exists, err := dc.mountExists(driver, driverOpts)
 	if err != nil {
-		httpError(w, "System failure retrieving mounts", err)
+		httpError(w, "Mountpoint existence check", err)
 		return
 	}
 
-	for _, mount := range mounts {
-		if mount.Path == driver.MountPath(driverOpts) {
-			httpError(w, "Mount already exists on this host", nil)
-			return
-		}
+	if exists {
+		httpError(w, "Mountpoint already in use", err)
+		return
 	}
 
 	ut := &config.UseMount{
@@ -318,30 +228,10 @@ func (dc *DaemonConfig) unmount(w http.ResponseWriter, r *http.Request) {
 
 	log.Infof("Unmounting volume %q", uc.Request.Name)
 
-	volConfig, err := dc.requestVolume(uc.Policy, uc.Name)
+	driver, volConfig, driverOpts, err := dc.structsVolumeName(uc)
 	if err != nil {
-		httpError(w, "Could not determine policy configuration", err)
+		httpError(w, "Configuring request", err)
 		return
-	}
-
-	driver, err := backend.NewDriver(volConfig.Backend, dc.Global.MountPath)
-	if err != nil {
-		httpError(w, fmt.Sprintf("loading driver"), err)
-		return
-	}
-
-	intName, err := driver.InternalName(uc.Request.Name)
-	if err != nil {
-		httpError(w, fmt.Sprintf("Volume %q does not satisfy name requirements", uc.Request.Name), err)
-		return
-	}
-
-	driverOpts := storage.DriverOptions{
-		Volume: storage.Volume{
-			Name:   intName,
-			Params: volConfig.DriverOptions,
-		},
-		Timeout: dc.Global.Timeout,
 	}
 
 	ut := &config.UseMount{

--- a/volplugin/handlers.go
+++ b/volplugin/handlers.go
@@ -192,7 +192,7 @@ func (dc *DaemonConfig) mount(w http.ResponseWriter, r *http.Request) {
 	}
 
 	ut := &config.UseMount{
-		Volume:   volConfig,
+		Volume:   volConfig.String(),
 		Hostname: dc.Host,
 	}
 
@@ -236,7 +236,7 @@ func (dc *DaemonConfig) unmount(w http.ResponseWriter, r *http.Request) {
 	}
 
 	ut := &config.UseMount{
-		Volume:   volConfig,
+		Volume:   volConfig.String(),
 		Hostname: dc.Host,
 	}
 

--- a/volplugin/runtime.go
+++ b/volplugin/runtime.go
@@ -1,0 +1,96 @@
+package volplugin
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"reflect"
+	"time"
+
+	"github.com/contiv/errored"
+	"github.com/contiv/volplugin/config"
+	"github.com/contiv/volplugin/storage"
+
+	log "github.com/Sirupsen/logrus"
+)
+
+func (dc *DaemonConfig) pollRuntime(volumeName string, mc *storage.Mount) {
+	for {
+		dc.runtimeMutex.RLock()
+		stop := dc.runtimeStopChans[volumeName]
+		dc.runtimeMutex.RUnlock()
+		select {
+		case <-stop:
+			return
+		case <-time.After(dc.Global.TTL):
+			log.Debugf("Checking runtime parameters for volume %q (ttl: %d)", volumeName, dc.Global.TTL)
+
+			log.Debugf("Requesting runtime configuration for volume %q", volumeName)
+			resp, err := http.Get(fmt.Sprintf("http://%s/runtime/%s", dc.Master, volumeName))
+			if err != nil {
+				log.Error(errored.Errorf("Error processing runtime update").Combine(err))
+				continue
+			}
+
+			if resp.StatusCode != 200 {
+				log.Error(errored.Errorf("Error processing request for runtime configuration of volume %q: status %d received", volumeName, resp.StatusCode))
+				continue
+			}
+
+			log.Debugf("Requesting runtime configuration for volume %q succeeded", volumeName)
+
+			content, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				log.Error(errored.Errorf("Error processing runtime update").Combine(err))
+				continue
+			}
+
+			resp.Body.Close()
+			var rt config.RuntimeOptions
+
+			if err := json.Unmarshal(content, &rt); err != nil {
+				log.Error(errored.Errorf("Error processing runtime update").Combine(err))
+				continue
+			}
+
+			log.Debugf("Comparing runtime configuration for volume %q", volumeName)
+			dc.runtimeMutex.RLock()
+			existing := dc.runtimeVolumeMap[volumeName]
+			dc.runtimeMutex.RUnlock()
+			if !reflect.DeepEqual(rt, existing) {
+				log.Debugf("Applying new cgroup rate limits for volume %q", volumeName)
+
+				if err := applyCGroupRateLimit(rt, mc); err != nil {
+					log.Error(errored.Errorf("Error processing runtime update").Combine(err))
+					continue
+				}
+
+				log.Debugf("Assigning new runtime configuration for volume %q", volumeName)
+				dc.runtimeMutex.Lock()
+				dc.runtimeVolumeMap[volumeName] = rt
+				dc.runtimeMutex.Unlock()
+			}
+		}
+	}
+}
+
+func (dc *DaemonConfig) stopRuntimePoll(volumeName string) {
+	dc.runtimeMutex.Lock()
+	if stop, ok := dc.runtimeStopChans[volumeName]; ok {
+		close(stop)
+		delete(dc.runtimeStopChans, volumeName)
+	}
+	dc.runtimeMutex.Unlock()
+}
+
+func (dc *DaemonConfig) startRuntimePoll(volumeName string, mc *storage.Mount) {
+	dc.runtimeMutex.Lock()
+	if _, ok := dc.runtimeStopChans[volumeName]; ok {
+		close(dc.runtimeStopChans[volumeName])
+	}
+	dc.runtimeStopChans[volumeName] = make(chan struct{})
+	dc.runtimeMutex.Unlock()
+
+	go dc.pollRuntime(volumeName, mc)
+}

--- a/volplugin/volplugin.go
+++ b/volplugin/volplugin.go
@@ -104,7 +104,7 @@ func (dc *DaemonConfig) configureRouter() *mux.Router {
 		"/Plugin.Activate":      dc.activate,
 		"/Plugin.Deactivate":    dc.nilAction,
 		"/VolumeDriver.Create":  dc.create,
-		"/VolumeDriver.Remove":  dc.remove,
+		"/VolumeDriver.Remove":  dc.getPath, // we never actually remove through docker's interface.
 		"/VolumeDriver.List":    dc.list,
 		"/VolumeDriver.Get":     dc.get,
 		"/VolumeDriver.Path":    dc.getPath,

--- a/volplugin/volplugin.go
+++ b/volplugin/volplugin.go
@@ -218,7 +218,7 @@ func (dc *DaemonConfig) updateMounts() error {
 
 			log.Infof("Refreshing existing mount for %q", mount.Volume.Name)
 
-			volConfig, err := dc.requestVolume(parts[0], parts[1])
+			_, err := dc.requestVolume(parts[0], parts[1])
 			switch err {
 			case errVolumeNotFound:
 				log.Warnf("Volume %q not found in database, skipping")
@@ -229,7 +229,7 @@ func (dc *DaemonConfig) updateMounts() error {
 
 			payload := &config.UseMount{
 				Hostname: dc.Host,
-				Volume:   volConfig,
+				Volume:   mount.Volume.Name,
 			}
 
 			if err := dc.Client.ReportMount(payload); err != nil {

--- a/volplugin/volplugin.go
+++ b/volplugin/volplugin.go
@@ -239,6 +239,7 @@ func (dc *DaemonConfig) updateMounts() error {
 				}
 			}
 
+			go dc.startRuntimePoll(mount.Volume.Name, mount)
 			go dc.Client.HeartbeatMount(dc.Global.TTL, payload, dc.Client.AddStopChan(mount.Volume.Name))
 		}
 	}

--- a/volplugin/volplugin/cli.go
+++ b/volplugin/volplugin/cli.go
@@ -45,10 +45,7 @@ func main() {
 }
 
 func run(ctx *cli.Context) {
-	dc := &volplugin.DaemonConfig{
-		Master: ctx.String("master"),
-		Host:   ctx.String("host-label"),
-	}
+	dc := volplugin.NewDaemonConfig(ctx.String("master"), ctx.String("host-label"))
 
 	if err := dc.Daemon(); err != nil {
 		fmt.Fprintf(os.Stderr, "\nError: %v\n\n", err)

--- a/volsupervisor/loop.go
+++ b/volsupervisor/loop.go
@@ -22,7 +22,7 @@ func (dc *DaemonConfig) pruneSnapshots(volume string, val *config.Volume) {
 	log.Infof("starting snapshot prune for %q", val.VolumeName)
 
 	uc := &config.UseSnapshot{
-		Volume: val,
+		Volume: val.String(),
 		Reason: lock.ReasonSnapshotPrune,
 	}
 
@@ -75,7 +75,7 @@ func (dc *DaemonConfig) createSnapshot(volume string, val *config.Volume) {
 	log.Infof("Snapshotting %q.", volume)
 
 	uc := &config.UseSnapshot{
-		Volume: val,
+		Volume: val.String(),
 		Reason: lock.ReasonSnapshot,
 	}
 

--- a/volsupervisor/loop.go
+++ b/volsupervisor/loop.go
@@ -27,7 +27,7 @@ func (dc *DaemonConfig) pruneSnapshots(volume string, val *config.Volume) {
 	}
 
 	err := lock.NewDriver(dc.Config).ExecuteWithUseLock(uc, func(ld *lock.Driver, uc config.UseLocker) error {
-		driver, err := backend.NewDriver(val.Options.Backend, dc.Global.MountPath)
+		driver, err := backend.NewDriver(val.Backend, dc.Global.MountPath)
 		if err != nil {
 			log.Errorf("failed to get driver: %v", err)
 			return err
@@ -37,7 +37,7 @@ func (dc *DaemonConfig) pruneSnapshots(volume string, val *config.Volume) {
 			Volume: storage.Volume{
 				Name: strings.Join([]string{val.PolicyName, val.VolumeName}, "."),
 				Params: storage.Params{
-					"pool": val.Options.Pool,
+					"pool": val.DriverOptions["pool"],
 				},
 			},
 			Timeout: dc.Global.Timeout,
@@ -49,9 +49,9 @@ func (dc *DaemonConfig) pruneSnapshots(volume string, val *config.Volume) {
 			return err
 		}
 
-		log.Debugf("Volume %q: keeping %d snapshots", val, val.Options.Snapshot.Keep)
+		log.Debugf("Volume %q: keeping %d snapshots", val, val.RuntimeOptions.Snapshot.Keep)
 
-		toDeleteCount := len(list) - int(val.Options.Snapshot.Keep)
+		toDeleteCount := len(list) - int(val.RuntimeOptions.Snapshot.Keep)
 		if toDeleteCount < 0 {
 			return nil
 		}
@@ -80,9 +80,9 @@ func (dc *DaemonConfig) createSnapshot(volume string, val *config.Volume) {
 	}
 
 	err := lock.NewDriver(dc.Config).ExecuteWithUseLock(uc, func(ld *lock.Driver, uc config.UseLocker) error {
-		driver, err := backend.NewDriver(val.Options.Backend, dc.Global.MountPath)
+		driver, err := backend.NewDriver(val.Backend, dc.Global.MountPath)
 		if err != nil {
-			log.Errorf("Error establishing driver backend %q; cannot snapshot", val.Options.Backend)
+			log.Errorf("Error establishing driver backend %q; cannot snapshot", val.Backend)
 			return err
 		}
 
@@ -90,7 +90,7 @@ func (dc *DaemonConfig) createSnapshot(volume string, val *config.Volume) {
 			Volume: storage.Volume{
 				Name: strings.Join([]string{val.PolicyName, val.VolumeName}, "."),
 				Params: storage.Params{
-					"pool": val.Options.Pool,
+					"pool": val.DriverOptions["pool"],
 				},
 			},
 			Timeout: dc.Global.Timeout,
@@ -123,8 +123,8 @@ func (dc *DaemonConfig) loop() {
 		volumeMutex.Unlock()
 
 		for volume, val := range volumeCopy {
-			if val.Options.UseSnapshots {
-				freq, err := time.ParseDuration(val.Options.Snapshot.Frequency)
+			if val.RuntimeOptions.UseSnapshots {
+				freq, err := time.ParseDuration(val.RuntimeOptions.Snapshot.Frequency)
 				if err != nil {
 					log.Errorf("Volume %q has an invalid frequency. Skipping snapshot.", volume)
 				}


### PR DESCRIPTION
The biggest change here is that double-creates will fail if coming from volcli (docker will swallow the create for us in the `docker volume create` case). Additionally, I have re-integrated volume create flags, so that you can set up initial parameters for the filesystem, etc.