### PR TITLE
Vagrantfile: use linked clones on VirtualBox

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -143,6 +143,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       end
 
       mon.vm.provider :virtualbox do |vb, override|
+        vb.linked_clone = true if Vagrant::VERSION =~ /^1.8/
+
         override.vm.network :private_network, ip: "#{SUBNET}.1#{i}", virtualbox__intnet: true
         override.vm.network :private_network, ip: "#{SUBNET}.2#{i}", virtualbox__intnet: true
 


### PR DESCRIPTION
This speeds up the VM provisioning through the use of linked clones for the VMs. This lowers the time required to create each VM from 20-50 seconds down to one second or less.