### PR TITLE
config,systemtests,volplugin: handle a number of situations where our…

### DIFF
--- a/config/use.go
+++ b/config/use.go
@@ -103,7 +103,7 @@ func (c *Client) PublishUse(ut UseLocker) error {
 	_, err = c.etcdClient.Set(context.Background(), c.use(ut.Type(), ut.GetVolume()), string(content), &client.SetOptions{PrevExist: client.PrevNoExist})
 	if _, ok := err.(client.Error); ok && err.(client.Error).Code == client.ErrorCodeNodeExist {
 		if ut.MayExist() {
-			_, err := c.etcdClient.Set(context.Background(), c.use(ut.Type(), ut.GetVolume()), string(content), &client.SetOptions{PrevValue: string(content)})
+			_, err := c.etcdClient.Set(context.Background(), c.use(ut.Type(), ut.GetVolume()), string(content), &client.SetOptions{PrevExist: client.PrevExist, PrevValue: string(content)})
 			return err
 		}
 	}

--- a/systemtests/integrated_test.go
+++ b/systemtests/integrated_test.go
@@ -32,6 +32,8 @@ func (s *systemtestSuite) TestIntegratedUseMountLock(c *C) {
 	}
 
 	c.Assert(s.clearContainers(), IsNil)
+	c.Assert(s.purgeVolume("mon1", "policy1", "test", false), IsNil)
+	c.Assert(s.createVolume("mon1", "policy1", "test", nil), IsNil)
 	c.Assert(s.vagrant.GetNode("mon1").RunCommand(dockerCmd), IsNil)
 
 	for _, nodeName := range []string{"mon0", "mon2"} {

--- a/systemtests/util_test.go
+++ b/systemtests/util_test.go
@@ -45,7 +45,9 @@ func (s *systemtestSuite) purgeVolume(host, policy, name string, purgeCeph bool)
 	log.Infof("Purging %s/%s. Purging ceph: %v", host, name, purgeCeph)
 
 	// ignore the error here so we get to the purge if we have to
-	s.vagrant.GetNode(host).RunCommand(fmt.Sprintf("docker volume rm %s/%s", policy, name))
+	if out, err := s.vagrant.GetNode(host).RunCommandWithOutput(fmt.Sprintf("docker volume rm %s/%s", policy, name)); err != nil {
+		log.Error(out, err)
+	}
 
 	defer func() {
 		if purgeCeph {

--- a/volplugin/mountcache.go
+++ b/volplugin/mountcache.go
@@ -1,0 +1,25 @@
+package volplugin
+
+import log "github.com/Sirupsen/logrus"
+
+func (dc *DaemonConfig) mountIncrement(volumeName string) int {
+	dc.mountMutex.Lock()
+	dc.mountCount[volumeName]++
+	retval := dc.mountCount[volumeName]
+	dc.mountMutex.Unlock()
+
+	log.Debugf("Increased mount count to %d for %q", retval, volumeName)
+
+	return retval
+}
+
+func (dc *DaemonConfig) mountDecrement(volumeName string) int {
+	dc.mountMutex.Lock()
+	dc.mountCount[volumeName]--
+	retval := dc.mountCount[volumeName]
+	dc.mountMutex.Unlock()
+
+	log.Debugf("Decreased mount count to %d for %q", retval, volumeName)
+
+	return retval
+}

--- a/volplugin/utils.go
+++ b/volplugin/utils.go
@@ -41,7 +41,7 @@ func (dc *DaemonConfig) structsVolumeName(uc *unmarshalledConfig) (storage.Drive
 	driverOpts := storage.DriverOptions{}
 	volConfig, err := dc.requestVolume(uc.Policy, uc.Name)
 	if err != nil {
-		return nil, nil, driverOpts, errored.Errorf("Could not determine policy configuration").Combine(err)
+		return nil, nil, driverOpts, err
 	}
 
 	driver, err := backend.NewDriver(volConfig.Backend, dc.Global.MountPath)


### PR DESCRIPTION
… model doesn't match docker's:

* fixup the systemtests to enable the multi mount same host test, improve some code quality.
* Use locks now verify that the content exists before comparing it.
* Handle "volume not found" errors in a way that lets docker consume it.
* Resolve a number of situations where input was not error checked, just silently returned.
* Use a reference counter to refuse mounts in situations where docker attempts
  to unmounts devices that belong to other containers.

Signed-off-by: Erik Hollensbe <erik+github@hollensbe.org>