### PR TITLE
Restructure storage drivers

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -76,3 +76,14 @@ func (c *Client) prefixed(strs ...string) string {
 
 	return str
 }
+
+// NotFound is a predicate to determine whether or not the error returned by
+// etcd was a notfound error.
+func NotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	_, ok := err.(client.Error)
+	return ok && err.(client.Error).Code == client.ErrorCodeKeyNotFound
+}

--- a/config/policy.go
+++ b/config/policy.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"path"
 
+	"github.com/contiv/errored"
 	"github.com/coreos/etcd/client"
 	"golang.org/x/net/context"
 )
@@ -110,6 +111,10 @@ func (cfg *Policy) Validate() error {
 
 	if err := cfg.CreateOptions.Validate(); err != nil {
 		return err
+	}
+
+	if cfg.Backend == "" {
+		return errored.Errorf("Backend was not specified in policy")
 	}
 
 	return cfg.RuntimeOptions.Validate()

--- a/storage/backend/backends.go
+++ b/storage/backend/backends.go
@@ -8,18 +8,56 @@ import (
 	"github.com/contiv/volplugin/storage/backend/null"
 )
 
-// Drivers is the map of string to storage.Driver.
-var Drivers = map[string]func(string) storage.Driver{
-	ceph.BackendName: ceph.NewDriver,
-	null.BackendName: null.NewDriver,
-	nfs.BackendName:  nfs.NewDriver,
+// MountDrivers is the map of string to storage.MountDriver.
+var MountDrivers = map[string]func(string) (storage.MountDriver, error){
+	ceph.BackendName: ceph.NewMountDriver,
+	null.BackendName: null.NewMountDriver,
+	nfs.BackendName:  nfs.NewMountDriver,
 }
 
-// NewDriver instantiates and return a storage backend instance of the specified type
-func NewDriver(backend, mountpath string) (storage.Driver, error) {
-	f, ok := Drivers[backend]
+// CRUDDrivers is the map of string to storage.CRUDDriver.
+var CRUDDrivers = map[string]func() (storage.CRUDDriver, error){
+	ceph.BackendName: ceph.NewCRUDDriver,
+	null.BackendName: null.NewCRUDDriver,
+}
+
+// SnapshotDrivers is the map of string to storage.SnapshotDriver.
+var SnapshotDrivers = map[string]func() (storage.SnapshotDriver, error){
+	ceph.BackendName: ceph.NewSnapshotDriver,
+	null.BackendName: null.NewSnapshotDriver,
+}
+
+// NewMountDriver instantiates and return a mount driver instance of the
+// specified type
+func NewMountDriver(backend, mountpath string) (storage.MountDriver, error) {
+	f, ok := MountDrivers[backend]
 	if !ok {
-		return nil, errored.Errorf("invalid driver backend: %q", backend)
+		return nil, errored.Errorf("invalid mount driver backend: %q", backend)
 	}
-	return f(mountpath), nil
+
+	if mountpath == "" {
+		return nil, errored.Errorf("mount path not specified, cannot continue")
+	}
+
+	return f(mountpath)
+}
+
+// NewCRUDDriver instantiates a CRUD Driver.
+func NewCRUDDriver(backend string) (storage.CRUDDriver, error) {
+	f, ok := CRUDDrivers[backend]
+	if !ok {
+		return nil, errored.Errorf("invalid CRUD driver backend: %q", backend)
+	}
+
+	return f()
+}
+
+// NewSnapshotDriver creates a SnapshotDriver based on the backend name.
+func NewSnapshotDriver(backend string) (storage.SnapshotDriver, error) {
+	f, ok := SnapshotDrivers[backend]
+	if !ok {
+		return nil, errored.Errorf("invalid snapshot driver backend: %q", backend)
+	}
+
+	return f()
 }

--- a/storage/backend/backends.go
+++ b/storage/backend/backends.go
@@ -4,6 +4,7 @@ import (
 	"github.com/contiv/errored"
 	"github.com/contiv/volplugin/storage"
 	"github.com/contiv/volplugin/storage/backend/ceph"
+	"github.com/contiv/volplugin/storage/backend/nfs"
 	"github.com/contiv/volplugin/storage/backend/null"
 )
 
@@ -11,6 +12,7 @@ import (
 var Drivers = map[string]func(string) storage.Driver{
 	ceph.BackendName: ceph.NewDriver,
 	null.BackendName: null.NewDriver,
+	nfs.BackendName:  nfs.NewDriver,
 }
 
 // NewDriver instantiates and return a storage backend instance of the specified type

--- a/storage/backend/ceph/util.go
+++ b/storage/backend/ceph/util.go
@@ -8,8 +8,12 @@ import (
 )
 
 // MountPath returns the path of a mount for a pool/volume.
-func (c *Driver) MountPath(do storage.DriverOptions) string {
-	return filepath.Join(c.mountpath, do.Volume.Params["pool"], do.Volume.Name)
+func (c *Driver) MountPath(do storage.DriverOptions) (string, error) {
+	volName, err := c.internalName(do.Volume.Name)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(c.mountpath, do.Volume.Params["pool"], volName), nil
 }
 
 // FIXME maybe this belongs in storage/ as it's more general?

--- a/storage/backend/nfs/nfs.go
+++ b/storage/backend/nfs/nfs.go
@@ -14,9 +14,9 @@ type Driver struct {
 // BackendName is the name of the driver.
 const BackendName = "nfs"
 
-// NewDriver constructs a new NFS driver.
-func NewDriver(mountPath string) storage.Driver {
-	return &Driver{mountpath: mountPath}
+// NewMountDriver constructs a new NFS driver.
+func NewMountDriver(mountPath string) (storage.MountDriver, error) {
+	return &Driver{mountpath: mountPath}, nil
 }
 
 // Name returns the string associated with the storage backed of the driver
@@ -76,4 +76,4 @@ func (d *Driver) InternalName(volName string) (string, error) { return "", nil }
 func (d *Driver) InternalNameToVolpluginName(intName string) string { return "" }
 
 // MountPath describes the path at which the volume should be mounted.
-func (d *Driver) MountPath(do storage.DriverOptions) string { return d.mountpath }
+func (d *Driver) MountPath(do storage.DriverOptions) (string, error) { return d.mountpath, nil }

--- a/storage/backend/nfs/nfs.go
+++ b/storage/backend/nfs/nfs.go
@@ -1,0 +1,79 @@
+package nfs
+
+import (
+	"time"
+
+	"github.com/contiv/volplugin/storage"
+)
+
+// Driver is a basic struct for controlling the NFS driver.
+type Driver struct {
+	mountpath string
+}
+
+// BackendName is the name of the driver.
+const BackendName = "nfs"
+
+// NewDriver constructs a new NFS driver.
+func NewDriver(mountPath string) storage.Driver {
+	return &Driver{mountpath: mountPath}
+}
+
+// Name returns the string associated with the storage backed of the driver
+func (d *Driver) Name() string { return BackendName }
+
+// Create a volume.
+func (d *Driver) Create(do storage.DriverOptions) error { return nil }
+
+// Format a volume.
+func (d *Driver) Format(do storage.DriverOptions) error { return nil }
+
+// Destroy a volume.
+func (d *Driver) Destroy(do storage.DriverOptions) error { return nil }
+
+// List Volumes. May be scoped by storage parameters or other data.
+func (d *Driver) List(lo storage.ListOptions) ([]storage.Volume, error) {
+	return []storage.Volume{}, nil
+}
+
+// Mount a Volume
+func (d *Driver) Mount(do storage.DriverOptions) (*storage.Mount, error) { return nil, nil }
+
+// Unmount a volume
+func (d *Driver) Unmount(do storage.DriverOptions) error { return nil }
+
+// Exists returns true if a volume exists. Otherwise, it returns false.
+func (d *Driver) Exists(do storage.DriverOptions) (bool, error) { return false, nil }
+
+// CreateSnapshot creates a named snapshot for the volume. Any error will be returned.
+func (d *Driver) CreateSnapshot(name string, do storage.DriverOptions) error { return nil }
+
+// RemoveSnapshot removes a named snapshot for the volume. Any error will be returned.
+func (d *Driver) RemoveSnapshot(name string, do storage.DriverOptions) error { return nil }
+
+// ListSnapshots returns an array of snapshot names provided a maximum number
+// of snapshots to be returned. Any error will be returned.
+func (d *Driver) ListSnapshots(do storage.DriverOptions) ([]string, error) { return []string{}, nil }
+
+// CopySnapshot copies a snapshot into a new volume. Takes a DriverOptions,
+// snap and volume name (string). Returns error on failure.
+func (d *Driver) CopySnapshot(do storage.DriverOptions, snapName string, volName string) error {
+	return nil
+}
+
+// Mounted shows any volumes that belong to volplugin on the host, in
+// their native representation. They yield a *Mount.
+func (d *Driver) Mounted(timeout time.Duration) ([]*storage.Mount, error) {
+	return []*storage.Mount{}, nil
+}
+
+// InternalName translates a volplugin `tenant/volume` name to an internal
+// name suitable for the driver. Yields an error if impossible.
+func (d *Driver) InternalName(volName string) (string, error) { return "", nil }
+
+// InternalNameToVolpluginName translates an internal name to a volplugin
+// `tenant/volume` syntax name.
+func (d *Driver) InternalNameToVolpluginName(intName string) string { return "" }
+
+// MountPath describes the path at which the volume should be mounted.
+func (d *Driver) MountPath(do storage.DriverOptions) string { return d.mountpath }

--- a/storage/backend/null/null.go
+++ b/storage/backend/null/null.go
@@ -1,6 +1,8 @@
 package null
 
 import (
+	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -30,78 +32,107 @@ func getFunctionName() string {
 //
 // This is intended for regressing volplugin
 type Driver struct {
-	mountpath string
-	created   map[string]bool
-	mounted   map[string]bool
+	BaseMountPath string
+	CreatedMap    map[string]bool
+	MountedMap    map[string]bool
 }
 
-// NewDriver is a generator for Driver structs. It is used by the storage
-// framework to yield new drivers on every creation.
-func NewDriver(mountpath string) storage.Driver {
-	log.Infof("In %s", getFunctionName())
-	if gNullDriver != nil {
-		return gNullDriver
+// New constructs an empty *Driver
+func New() *Driver {
+	if gNullDriver == nil {
+		gNullDriver = &Driver{
+			CreatedMap: make(map[string]bool),
+			MountedMap: make(map[string]bool),
+		}
 	}
-	gNullDriver = &Driver{
-		mountpath: mountpath,
-		created:   make(map[string]bool),
-		mounted:   make(map[string]bool),
-	}
+
 	return gNullDriver
+}
+
+// NewMountDriver is a generator for Driver structs. It is used by the storage
+// framework to yield new drivers on every creation.
+func NewMountDriver(BaseMountPath string) (storage.MountDriver, error) {
+	log.Infof("In %s", getFunctionName())
+	driver := New()
+	driver.BaseMountPath = BaseMountPath
+
+	return driver, nil
+}
+
+// NewSnapshotDriver is a generator for Driver structs. It is used by the storage
+// framework to yield new drivers on every creation.
+func NewSnapshotDriver() (storage.SnapshotDriver, error) {
+	return New(), nil
+}
+
+// NewCRUDDriver is a generator for Driver structs. It is used by the storage
+// framework to yield new drivers on every creation.
+func NewCRUDDriver() (storage.CRUDDriver, error) {
+	return New(), nil
+}
+
+func (d *Driver) logStat(funcName string) {
+	log.Infof("In %q:", funcName)
+	content, err := json.MarshalIndent(d, "\t", "  ")
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("\t" + string(content))
 }
 
 // Name returns the null backend string
 func (d *Driver) Name() string {
-	log.Infof("In %q", getFunctionName())
+	d.logStat(getFunctionName())
 	return BackendName
 }
 
 // Create records created volume.
 func (d *Driver) Create(do storage.DriverOptions) error {
-	log.Infof("In %q", getFunctionName())
-	d.created[filepath.Join(d.mountpath, do.Volume.Params["pool"], do.Volume.Name)] = true
+	d.logStat(getFunctionName())
+	d.CreatedMap[filepath.Join(d.BaseMountPath, do.Volume.Params["pool"], do.Volume.Name)] = true
 	return nil
 }
 
 // Format is a noop.
 func (d *Driver) Format(do storage.DriverOptions) error {
-	log.Infof("In %q", getFunctionName())
+	d.logStat(getFunctionName())
 	return nil
 }
 
 // Destroy deletes volume entry
 func (d *Driver) Destroy(do storage.DriverOptions) error {
-	log.Infof("In %q", getFunctionName())
-	delete(d.created, filepath.Join(d.mountpath, do.Volume.Params["pool"], do.Volume.Name))
+	d.logStat(getFunctionName())
+	delete(d.CreatedMap, filepath.Join(d.BaseMountPath, do.Volume.Params["pool"], do.Volume.Name))
 	return nil
 }
 
 // List Volumes returns empty list.
 func (d *Driver) List(lo storage.ListOptions) ([]storage.Volume, error) {
+	d.logStat(getFunctionName())
 	log.Infof("In %q", getFunctionName())
 	return []storage.Volume{}, nil
 }
 
 // Mount records mounted volume
 func (d *Driver) Mount(do storage.DriverOptions) (*storage.Mount, error) {
-	log.Infof("In %q", getFunctionName())
-	if err := os.MkdirAll(d.mountpath, 0700); err != nil && !os.IsExist(err) {
-		return nil, errored.Errorf("error creating %q directory: %v", d.mountpath, err)
+	d.logStat(getFunctionName())
+	if err := os.MkdirAll(d.BaseMountPath, 0700); err != nil && !os.IsExist(err) {
+		return nil, errored.Errorf("error creating %q directory: %v", d.BaseMountPath, err)
 	}
 
-	volumePath := filepath.Join(d.mountpath, do.Volume.Params["pool"], do.Volume.Name)
+	volumePath := filepath.Join(d.BaseMountPath, do.Volume.Params["pool"], do.Volume.Name)
 	if err := os.MkdirAll(volumePath, 0700); err != nil && !os.IsExist(err) {
 		return nil, errored.Errorf("error creating %q directory: %v", volumePath, err)
 	}
-	d.mounted[filepath.Join(d.mountpath, do.Volume.Params["pool"], do.Volume.Name)] = true
+	d.MountedMap[filepath.Join(d.BaseMountPath, do.Volume.Params["pool"], do.Volume.Name)] = true
 	return nil, nil
 }
 
-// Unmount deleted mounted volume entry.
+// Unmount deletes mounted entry.
 func (d *Driver) Unmount(do storage.DriverOptions) error {
-	log.Infof("In %q", getFunctionName())
-	delete(d.mounted, filepath.Join(d.mountpath, do.Volume.Params["pool"], do.Volume.Name))
-	volumePath := filepath.Join(d.mountpath, do.Volume.Params["pool"], do.Volume.Name)
+	d.logStat(getFunctionName())
+	delete(d.MountedMap, filepath.Join(d.BaseMountPath, do.Volume.Params["pool"], do.Volume.Name))
+	volumePath := filepath.Join(d.BaseMountPath, do.Volume.Params["pool"], do.Volume.Name)
 	if err := os.RemoveAll(volumePath); err != nil {
 		return errored.Errorf("error deleting %q directory: %v", volumePath, err)
 	}
@@ -110,57 +141,45 @@ func (d *Driver) Unmount(do storage.DriverOptions) error {
 
 // Exists returns false always.
 func (d *Driver) Exists(do storage.DriverOptions) (bool, error) {
-	log.Infof("In %q", getFunctionName())
-	if _, ok := d.created[filepath.Join(d.mountpath, do.Volume.Params["pool"], do.Volume.Name)]; !ok {
-		return false, errored.Errorf("volume not created")
+	d.logStat(getFunctionName())
+	if _, ok := d.CreatedMap[filepath.Join(d.BaseMountPath, do.Volume.Params["pool"], do.Volume.Name)]; !ok {
+		return false, errored.Errorf("volume not CreatedMap: %#v", d.CreatedMap)
 	}
 	return true, nil
 }
 
 // CreateSnapshot is a noop.
 func (d *Driver) CreateSnapshot(s string, do storage.DriverOptions) error {
-	log.Infof("In %q", getFunctionName())
+	d.logStat(getFunctionName())
 	return nil
 }
 
 // RemoveSnapshot is a noop.
 func (d *Driver) RemoveSnapshot(s string, do storage.DriverOptions) error {
-	log.Infof("In %q", getFunctionName())
+	d.logStat(getFunctionName())
 	return nil
 }
 
 // CopySnapshot is a noop.
 func (d *Driver) CopySnapshot(do storage.DriverOptions, s, s2 string) error {
-	log.Infof("In %q", getFunctionName())
+	d.logStat(getFunctionName())
 	return nil
 }
 
 // ListSnapshots returns an empty list.
 func (d *Driver) ListSnapshots(do storage.DriverOptions) ([]string, error) {
-	log.Infof("In %q", getFunctionName())
+	d.logStat(getFunctionName())
 	return []string{}, nil
 }
 
 // Mounted retuns an empty list.
 func (d *Driver) Mounted(t time.Duration) ([]*storage.Mount, error) {
-	log.Infof("In %q", getFunctionName())
+	d.logStat(getFunctionName())
 	return []*storage.Mount{}, nil
 }
 
-// InternalName returns the passed string as is.
-func (d *Driver) InternalName(s string) (string, error) {
-	log.Infof("In %q", getFunctionName())
-	return s, nil
-}
-
-// InternalNameToVolpluginName returns the passed string as is.
-func (d *Driver) InternalNameToVolpluginName(s string) string {
-	log.Infof("In %q", getFunctionName())
-	return s
-}
-
 // MountPath describes the path at which the volume should be mounted.
-func (d *Driver) MountPath(do storage.DriverOptions) string {
-	log.Infof("In %q", getFunctionName())
-	return filepath.Join(d.mountpath, do.Volume.Params["pool"], do.Volume.Name)
+func (d *Driver) MountPath(do storage.DriverOptions) (string, error) {
+	d.logStat(getFunctionName())
+	return filepath.Join(d.BaseMountPath, do.Volume.Params["pool"], do.Volume.Name), nil
 }

--- a/storage/driver.go
+++ b/storage/driver.go
@@ -49,14 +49,40 @@ type Volume struct {
 	Params
 }
 
+// NamedDriver is a named driver and has a method called Name()
+type NamedDriver interface {
+	// Name returns the string associated with the storage backed of the driver
+	Name() string
+}
+
 // Driver is a full driver that implements a storage function available to
 // volplugin. Drivers are called anywhere filesystem operations are necessary.
 // Consumers should do this through the NewStorage call and associated member
 // functions.
 type Driver interface {
-	// Name returns the string associated with the storage backed of the driver
-	Name() string
+	NamedDriver
+	CRUDDriver
+	SnapshotDriver
+	MountDriver
+}
 
+// MountDriver mounts volumes.
+type MountDriver interface {
+	// Mount a Volume
+	Mount(DriverOptions) (*Mount, error)
+
+	// Unmount a volume
+	Unmount(DriverOptions) error
+	// Mounted shows any volumes that belong to volplugin on the host, in
+	// their native representation. They yield a *Mount.
+	Mounted(time.Duration) ([]*Mount, error)
+
+	// MountPath describes the path at which the volume should be mounted.
+	MountPath(DriverOptions) string
+}
+
+// CRUDDriver performs CRUD operations.
+type CRUDDriver interface {
 	// Create a volume.
 	Create(DriverOptions) error
 
@@ -69,15 +95,20 @@ type Driver interface {
 	// List Volumes. May be scoped by storage parameters or other data.
 	List(ListOptions) ([]Volume, error)
 
-	// Mount a Volume
-	Mount(DriverOptions) (*Mount, error)
-
-	// Unmount a volume
-	Unmount(DriverOptions) error
-
 	// Exists returns true if a volume exists. Otherwise, it returns false.
 	Exists(DriverOptions) (bool, error)
 
+	// InternalName translates a volplugin `tenant/volume` name to an internal
+	// name suitable for the driver. Yields an error if impossible.
+	InternalName(string) (string, error)
+
+	// InternalNameToVolpluginName translates an internal name to a volplugin
+	// `tenant/volume` syntax name.
+	InternalNameToVolpluginName(string) string
+}
+
+// SnapshotDriver manages snapshots.
+type SnapshotDriver interface {
 	// CreateSnapshot creates a named snapshot for the volume. Any error will be returned.
 	CreateSnapshot(string, DriverOptions) error
 
@@ -91,19 +122,4 @@ type Driver interface {
 	// CopySnapshot copies a snapshot into a new volume. Takes a DriverOptions,
 	// snap and volume name (string). Returns error on failure.
 	CopySnapshot(DriverOptions, string, string) error
-
-	// Mounted shows any volumes that belong to volplugin on the host, in
-	// their native representation. They yield a *Mount.
-	Mounted(time.Duration) ([]*Mount, error)
-
-	// InternalName translates a volplugin `tenant/volume` name to an internal
-	// name suitable for the driver. Yields an error if impossible.
-	InternalName(string) (string, error)
-
-	// InternalNameToVolpluginName translates an internal name to a volplugin
-	// `tenant/volume` syntax name.
-	InternalNameToVolpluginName(string) string
-
-	// MountPath describes the path at which the volume should be mounted.
-	MountPath(DriverOptions) string
 }

--- a/storage/driver.go
+++ b/storage/driver.go
@@ -55,34 +55,28 @@ type NamedDriver interface {
 	Name() string
 }
 
-// Driver is a full driver that implements a storage function available to
-// volplugin. Drivers are called anywhere filesystem operations are necessary.
-// Consumers should do this through the NewStorage call and associated member
-// functions.
-type Driver interface {
-	NamedDriver
-	CRUDDriver
-	SnapshotDriver
-	MountDriver
-}
-
 // MountDriver mounts volumes.
 type MountDriver interface {
+	NamedDriver
+
 	// Mount a Volume
 	Mount(DriverOptions) (*Mount, error)
 
 	// Unmount a volume
 	Unmount(DriverOptions) error
+
 	// Mounted shows any volumes that belong to volplugin on the host, in
 	// their native representation. They yield a *Mount.
 	Mounted(time.Duration) ([]*Mount, error)
 
 	// MountPath describes the path at which the volume should be mounted.
-	MountPath(DriverOptions) string
+	MountPath(DriverOptions) (string, error)
 }
 
 // CRUDDriver performs CRUD operations.
 type CRUDDriver interface {
+	NamedDriver
+
 	// Create a volume.
 	Create(DriverOptions) error
 
@@ -97,18 +91,12 @@ type CRUDDriver interface {
 
 	// Exists returns true if a volume exists. Otherwise, it returns false.
 	Exists(DriverOptions) (bool, error)
-
-	// InternalName translates a volplugin `tenant/volume` name to an internal
-	// name suitable for the driver. Yields an error if impossible.
-	InternalName(string) (string, error)
-
-	// InternalNameToVolpluginName translates an internal name to a volplugin
-	// `tenant/volume` syntax name.
-	InternalNameToVolpluginName(string) string
 }
 
 // SnapshotDriver manages snapshots.
 type SnapshotDriver interface {
+	NamedDriver
+
 	// CreateSnapshot creates a named snapshot for the volume. Any error will be returned.
 	CreateSnapshot(string, DriverOptions) error
 

--- a/systemtests/init_test.go
+++ b/systemtests/init_test.go
@@ -35,7 +35,7 @@ func (s *systemtestSuite) SetUpSuite(c *C) {
 	c.Assert(s.vagrant.Setup(false, "", 3), IsNil)
 
 	stopServices := []string{"volplugin", "volmaster", "volsupervisor"}
-	startServices := []string{""}
+	startServices := []string{}
 	if cephDriver() {
 		startServices = append(startServices, "ceph.target")
 	} else {
@@ -44,7 +44,6 @@ func (s *systemtestSuite) SetUpSuite(c *C) {
 	for _, service := range stopServices {
 		for _, node := range s.vagrant.GetNodes() {
 			node.RunCommand(fmt.Sprintf("sudo systemctl stop %s", service))
-			node.RunCommand(fmt.Sprintf("sudo systemctl disable %s", service))
 		}
 	}
 	for _, service := range startServices {
@@ -58,4 +57,11 @@ func (s *systemtestSuite) SetUpSuite(c *C) {
 
 	out, err := s.uploadIntent("policy1", "policy1")
 	c.Assert(err, IsNil, Commentf("output: %s", out))
+}
+
+func (s *systemtestSuite) TearDownSuite(c *C) {
+	// XXX ensure ceph is always running at the end of the run
+	for _, node := range s.vagrant.GetNodes() {
+		node.RunCommand("sudo systemctl start ceph.target")
+	}
 }

--- a/systemtests/testdata/ceph/global-fasttimeout.json
+++ b/systemtests/testdata/ceph/global-fasttimeout.json
@@ -1,5 +1,6 @@
 {
   "TTL": 5,
   "Debug": true,
-  "Timeout": 1
+  "Timeout": 1,
+  "Backend": "ceph"
 }

--- a/systemtests/testdata/ceph/global1.json
+++ b/systemtests/testdata/ceph/global1.json
@@ -1,5 +1,6 @@
 {
   "TTL": 30,
   "Debug": true,
-  "Timeout": 10
+  "Timeout": 10,
+  "Backend": "ceph"
 }

--- a/systemtests/testdata/ceph/global2.json
+++ b/systemtests/testdata/ceph/global2.json
@@ -1,5 +1,6 @@
 {
   "Debug": false,
   "TTL": 30,
-  "Timeout": 30
+  "Timeout": 30,
+  "Backend": "ceph"
 }

--- a/systemtests/testdata/ceph/mountpath_global.json
+++ b/systemtests/testdata/ceph/mountpath_global.json
@@ -2,5 +2,6 @@
   "TTL": 5,
   "Debug": true,
   "Timeout": 10,
-  "MountPath": "/mnt/test"
+  "MountPath": "/mnt/test",
+  "Backend": "ceph"
 }

--- a/volmaster/volume.go
+++ b/volmaster/volume.go
@@ -33,19 +33,14 @@ func (dc *DaemonConfig) createVolume(policy *config.Policy, config *config.Volum
 		return storage.DriverOptions{}, err
 	}
 
-	driver, err := backend.NewDriver(config.Backend, dc.Global.MountPath)
-	if err != nil {
-		return storage.DriverOptions{}, err
-	}
-
-	intName, err := driver.InternalName(config.String())
+	driver, err := backend.NewCRUDDriver(dc.Global.Backend)
 	if err != nil {
 		return storage.DriverOptions{}, err
 	}
 
 	driverOpts := storage.DriverOptions{
 		Volume: storage.Volume{
-			Name:   intName,
+			Name:   config.String(),
 			Size:   actualSize,
 			Params: config.DriverOptions,
 		},
@@ -66,32 +61,24 @@ func (dc *DaemonConfig) formatVolume(config *config.Volume, do storage.DriverOpt
 		return err
 	}
 
-	driver, err := backend.NewDriver(config.Backend, dc.Global.MountPath)
-	if err != nil {
-		return err
-	}
-	intName, err := driver.InternalName(config.String())
+	driver, err := backend.NewCRUDDriver(dc.Global.Backend)
 	if err != nil {
 		return err
 	}
 
-	log.Infof("Formatting volume %v (filesystem %q) with size %d", intName, config.CreateOptions.FileSystem, actualSize)
+	log.Infof("Formatting volume %v (filesystem %q) with size %d", config, config.CreateOptions.FileSystem, actualSize)
 	return driver.Format(do)
 }
 
 func (dc *DaemonConfig) existsVolume(config *config.Volume) (bool, error) {
-	driver, err := backend.NewDriver(config.Backend, dc.Global.MountPath)
-	if err != nil {
-		return false, err
-	}
-	intName, err := driver.InternalName(config.String())
+	driver, err := backend.NewCRUDDriver(dc.Global.Backend)
 	if err != nil {
 		return false, err
 	}
 
 	driverOpts := storage.DriverOptions{
 		Volume: storage.Volume{
-			Name:   intName,
+			Name:   config.String(),
 			Params: config.DriverOptions,
 		},
 		Timeout: dc.Global.Timeout,
@@ -101,18 +88,14 @@ func (dc *DaemonConfig) existsVolume(config *config.Volume) (bool, error) {
 }
 
 func (dc *DaemonConfig) removeVolume(config *config.Volume, timeout time.Duration) error {
-	driver, err := backend.NewDriver(config.Backend, dc.Global.MountPath)
-	if err != nil {
-		return err
-	}
-	intName, err := driver.InternalName(config.String())
+	driver, err := backend.NewCRUDDriver(dc.Global.Backend)
 	if err != nil {
 		return err
 	}
 
 	driverOpts := storage.DriverOptions{
 		Volume: storage.Volume{
-			Name:   intName,
+			Name:   config.String(),
 			Params: config.DriverOptions,
 		},
 		Timeout: timeout,

--- a/volplugin/volplugin.go
+++ b/volplugin/volplugin.go
@@ -202,8 +202,8 @@ func (dc *DaemonConfig) watchGlobal() error {
 }
 
 func (dc *DaemonConfig) updateMounts() error {
-	for driverName := range backend.Drivers {
-		cd, err := backend.NewDriver(driverName, dc.Global.MountPath)
+	for driverName := range backend.MountDrivers {
+		cd, err := backend.NewMountDriver(driverName, dc.Global.MountPath)
 		if err != nil {
 			return err
 		}

--- a/volsupervisor/loop.go
+++ b/volsupervisor/loop.go
@@ -1,7 +1,6 @@
 package volsupervisor
 
 import (
-	"strings"
 	"sync"
 	"time"
 
@@ -27,7 +26,7 @@ func (dc *DaemonConfig) pruneSnapshots(volume string, val *config.Volume) {
 	}
 
 	err := lock.NewDriver(dc.Config).ExecuteWithUseLock(uc, func(ld *lock.Driver, uc config.UseLocker) error {
-		driver, err := backend.NewDriver(val.Backend, dc.Global.MountPath)
+		driver, err := backend.NewSnapshotDriver(val.Backend)
 		if err != nil {
 			log.Errorf("failed to get driver: %v", err)
 			return err
@@ -35,7 +34,7 @@ func (dc *DaemonConfig) pruneSnapshots(volume string, val *config.Volume) {
 
 		driverOpts := storage.DriverOptions{
 			Volume: storage.Volume{
-				Name: strings.Join([]string{val.PolicyName, val.VolumeName}, "."),
+				Name: val.String(),
 				Params: storage.Params{
 					"pool": val.DriverOptions["pool"],
 				},
@@ -80,7 +79,7 @@ func (dc *DaemonConfig) createSnapshot(volume string, val *config.Volume) {
 	}
 
 	err := lock.NewDriver(dc.Config).ExecuteWithUseLock(uc, func(ld *lock.Driver, uc config.UseLocker) error {
-		driver, err := backend.NewDriver(val.Backend, dc.Global.MountPath)
+		driver, err := backend.NewSnapshotDriver(val.Backend)
 		if err != nil {
 			log.Errorf("Error establishing driver backend %q; cannot snapshot", val.Backend)
 			return err
@@ -88,7 +87,7 @@ func (dc *DaemonConfig) createSnapshot(volume string, val *config.Volume) {
 
 		driverOpts := storage.DriverOptions{
 			Volume: storage.Volume{
-				Name: strings.Join([]string{val.PolicyName, val.VolumeName}, "."),
+				Name: val.String(),
 				Params: storage.Params{
 					"pool": val.DriverOptions["pool"],
 				},


### PR DESCRIPTION
This provides an implementation of a stub NFS driver + a revisitation of storage drivers in general.

Drivers are now split into Mount, Snapshot, and CRUD (Create/Retrieve/Update/Delete) drivers. Each driver has its own unique sets of methods (except for Name, which is shared through `storage.NamedDriver`) that do not overlap. To operate with a driver, you use the `backend` library to take it, then perform operations on it based on the standard interfaces.

Now, drivers do not have to provide functionality for every subsystem, just the ones they support. Future patches will implement this integration as we get more storage capabilities.