### PR TITLE
Null driver

### DIFF
--- a/config/global.go
+++ b/config/global.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"time"
 
-	"github.com/contiv/volplugin/storage/backend/ceph"
 	"github.com/contiv/volplugin/watch"
 	"github.com/coreos/etcd/client"
 	"golang.org/x/net/context"
@@ -26,7 +25,6 @@ type Global struct {
 	Debug     bool
 	Timeout   time.Duration
 	TTL       time.Duration
-	Backend   string
 	MountPath string
 }
 
@@ -34,7 +32,6 @@ type Global struct {
 func NewGlobalConfig() *Global {
 	return &Global{
 		TTL:       DefaultGlobalTTL,
-		Backend:   ceph.BackendName,
 		MountPath: defaultMountPath,
 		Timeout:   10 * time.Minute,
 	}

--- a/config/global_test.go
+++ b/config/global_test.go
@@ -13,7 +13,6 @@ func (s *configSuite) TestGlobal(c *C) {
 		Debug:     true,
 		TTL:       10,
 		Timeout:   1,
-		Backend:   "foo",
 		MountPath: defaultMountPath,
 	}
 
@@ -41,7 +40,6 @@ func (s *configSuite) TestGlobalWatch(c *C) {
 		Debug:     true,
 		TTL:       10,
 		Timeout:   1,
-		Backend:   "foo",
 		MountPath: defaultMountPath,
 	}
 

--- a/config/policy.go
+++ b/config/policy.go
@@ -5,6 +5,7 @@ import (
 	"path"
 
 	"github.com/contiv/errored"
+	"github.com/contiv/volplugin/storage/backend/ceph"
 	"github.com/coreos/etcd/client"
 	"golang.org/x/net/context"
 )
@@ -20,9 +21,9 @@ type Policy struct {
 }
 
 // NewPolicy return policy config with specified backend preset
-func NewPolicy(backend string) *Policy {
+func NewPolicy() *Policy {
 	return &Policy{
-		Backend: backend,
+		Backend: ceph.BackendName,
 	}
 }
 

--- a/storage/backend/backends.go
+++ b/storage/backend/backends.go
@@ -5,6 +5,7 @@ import (
 	"github.com/contiv/volplugin/storage"
 	"github.com/contiv/volplugin/storage/backend/ceph"
 	"github.com/contiv/volplugin/storage/backend/nfs"
+	"github.com/contiv/volplugin/storage/backend/null"
 	"github.com/contiv/volplugin/storage/backend/test"
 )
 
@@ -19,12 +20,14 @@ var MountDrivers = map[string]func(string) (storage.MountDriver, error){
 var CRUDDrivers = map[string]func() (storage.CRUDDriver, error){
 	ceph.BackendName: ceph.NewCRUDDriver,
 	test.BackendName: test.NewCRUDDriver,
+	null.BackendName: null.NewCRUDDriver,
 }
 
 // SnapshotDrivers is the map of string to storage.SnapshotDriver.
 var SnapshotDrivers = map[string]func() (storage.SnapshotDriver, error){
 	ceph.BackendName: ceph.NewSnapshotDriver,
 	test.BackendName: test.NewSnapshotDriver,
+	null.BackendName: null.NewSnapshotDriver,
 }
 
 // NewMountDriver instantiates and return a mount driver instance of the

--- a/storage/backend/null/null.go
+++ b/storage/backend/null/null.go
@@ -1,0 +1,69 @@
+package null
+
+import "github.com/contiv/volplugin/storage"
+
+// Driver for null operations. Does nothing.
+type Driver struct{}
+
+// BackendName is the name of the driver
+var BackendName = "null"
+
+// NewCRUDDriver is a null form of the CRUD driver, that does nothing.
+func NewCRUDDriver() (storage.CRUDDriver, error) {
+	return &Driver{}, nil
+}
+
+// NewSnapshotDriver creates a new null snapshot driver.
+func NewSnapshotDriver() (storage.SnapshotDriver, error) {
+	return &Driver{}, nil
+}
+
+// Name is the name of the driver
+func (d *Driver) Name() string {
+	return BackendName
+}
+
+// Create creates nothing.
+func (d *Driver) Create(storage.DriverOptions) error {
+	return nil
+}
+
+// Format formats nothing.
+func (d *Driver) Format(storage.DriverOptions) error {
+	return nil
+}
+
+// Destroy destroys nothing.
+func (d *Driver) Destroy(storage.DriverOptions) error {
+	return nil
+}
+
+// Exists does nothing.
+func (d *Driver) Exists(storage.DriverOptions) (bool, error) {
+	return false, nil
+}
+
+// List does nothing.
+func (d *Driver) List(storage.ListOptions) ([]storage.Volume, error) {
+	return []storage.Volume{}, nil
+}
+
+// CreateSnapshot does nothing.
+func (d *Driver) CreateSnapshot(string, storage.DriverOptions) error {
+	return nil
+}
+
+// RemoveSnapshot removes nothing.
+func (d *Driver) RemoveSnapshot(string, storage.DriverOptions) error {
+	return nil
+}
+
+// ListSnapshots lists nothing.
+func (d *Driver) ListSnapshots(storage.DriverOptions) ([]string, error) {
+	return []string{}, nil
+}
+
+// CopySnapshot copies nothing.
+func (d *Driver) CopySnapshot(storage.DriverOptions, string, string) error {
+	return nil
+}

--- a/systemtests/testdata/ceph/global-fasttimeout.json
+++ b/systemtests/testdata/ceph/global-fasttimeout.json
@@ -1,6 +1,5 @@
 {
   "TTL": 5,
   "Debug": true,
-  "Timeout": 1,
-  "Backend": "ceph"
+  "Timeout": 1
 }

--- a/systemtests/testdata/ceph/global1.json
+++ b/systemtests/testdata/ceph/global1.json
@@ -1,6 +1,5 @@
 {
   "TTL": 30,
   "Debug": true,
-  "Timeout": 10,
-  "Backend": "ceph"
+  "Timeout": 10
 }

--- a/systemtests/testdata/ceph/global2.json
+++ b/systemtests/testdata/ceph/global2.json
@@ -1,6 +1,5 @@
 {
   "Debug": false,
   "TTL": 30,
-  "Timeout": 30,
-  "Backend": "ceph"
+  "Timeout": 30
 }

--- a/systemtests/testdata/ceph/mountpath_global.json
+++ b/systemtests/testdata/ceph/mountpath_global.json
@@ -2,6 +2,5 @@
   "TTL": 5,
   "Debug": true,
   "Timeout": 10,
-  "MountPath": "/mnt/test",
-  "Backend": "ceph"
+  "MountPath": "/mnt/test"
 }

--- a/systemtests/testdata/test/global1.json
+++ b/systemtests/testdata/test/global1.json
@@ -1,6 +1,5 @@
 {
   "TTL": 30,
   "Debug": true,
-  "Timeout": 10,
-  "Backend" : "test"
+  "Timeout": 10
 }

--- a/systemtests/util_test.go
+++ b/systemtests/util_test.go
@@ -12,7 +12,6 @@ import (
 	utils "github.com/contiv/systemtests-utils"
 	"github.com/contiv/vagrantssh"
 	"github.com/contiv/volplugin/config"
-	"github.com/contiv/volplugin/storage/backend/ceph"
 )
 
 func (s *systemtestSuite) mon0cmd(command string) (string, error) {
@@ -33,7 +32,7 @@ func (s *systemtestSuite) readIntent(fn string) (*config.Policy, error) {
 		return nil, err
 	}
 
-	cfg := config.NewPolicy(ceph.BackendName)
+	cfg := config.NewPolicy()
 
 	if err := json.Unmarshal(content, cfg); err != nil {
 		return nil, err

--- a/systemtests/volcli_test.go
+++ b/systemtests/volcli_test.go
@@ -8,7 +8,6 @@ import (
 	. "gopkg.in/check.v1"
 
 	"github.com/contiv/volplugin/config"
-	"github.com/contiv/volplugin/storage/backend/ceph"
 )
 
 func (s *systemtestSuite) TestVolCLIPolicy(c *C) {
@@ -43,7 +42,7 @@ func (s *systemtestSuite) TestVolCLIPolicy(c *C) {
 	out, err := s.volcli("policy get test1")
 	c.Assert(err, IsNil)
 
-	intentTarget := config.NewPolicy(ceph.BackendName)
+	intentTarget := config.NewPolicy()
 	c.Assert(json.Unmarshal([]byte(out), intentTarget), IsNil)
 	policy1.FileSystems = map[string]string{"ext4": "mkfs.ext4 -m0 %"}
 
@@ -53,7 +52,7 @@ func (s *systemtestSuite) TestVolCLIPolicy(c *C) {
 	out, err = s.volcli("policy get test2")
 	c.Assert(err, IsNil)
 
-	intentTarget = config.NewPolicy(ceph.BackendName)
+	intentTarget = config.NewPolicy()
 	c.Assert(json.Unmarshal([]byte(out), intentTarget), IsNil)
 	policy2.FileSystems = map[string]string{"ext4": "mkfs.ext4 -m0 %"}
 	c.Assert(policy2, DeepEquals, intentTarget)
@@ -84,7 +83,7 @@ func (s *systemtestSuite) TestVolCLIPolicyNullDriver(c *C) {
 
 	out, err = s.volcli("policy get test")
 	c.Assert(err, IsNil, Commentf("output: %s", out))
-	intentTarget := config.NewPolicy("")
+	intentTarget := config.NewPolicy()
 	c.Assert(json.Unmarshal([]byte(out), intentTarget), IsNil)
 	testDriverIntent.FileSystems = map[string]string{"ext4": "mkfs.ext4 -m0 %"}
 	c.Assert(testDriverIntent, DeepEquals, intentTarget)

--- a/volcli/volcli.go
+++ b/volcli/volcli.go
@@ -161,12 +161,7 @@ func policyUpload(ctx *cli.Context) (bool, error) {
 		return false, err
 	}
 
-	global, err := queryGlobalConfig(ctx)
-	if err != nil {
-		return false, err
-	}
-
-	policy := config.NewPolicy(global.Backend)
+	policy := config.NewPolicy()
 
 	if err := json.Unmarshal(content, policy); err != nil {
 		return false, err

--- a/volmaster/daemon.go
+++ b/volmaster/daemon.go
@@ -176,7 +176,7 @@ func (d *DaemonConfig) handleSnapshotList(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	driver, err := backend.NewSnapshotDriver(d.Global.Backend)
+	driver, err := backend.NewSnapshotDriver(volConfig.Backend)
 	if err != nil {
 		httpError(w, "Constructing driver:", err)
 		return
@@ -227,15 +227,15 @@ func (d *DaemonConfig) handleCopy(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	driver, err := backend.NewSnapshotDriver(d.Global.Backend)
-	if err != nil {
-		httpError(w, "Constructing driver:", err)
-		return
-	}
-
 	volConfig, err := d.Config.GetVolume(req.Policy, req.Volume)
 	if err != nil {
 		httpError(w, "Retrieving original volume", err)
+		return
+	}
+
+	driver, err := backend.NewSnapshotDriver(volConfig.Backend)
+	if err != nil {
+		httpError(w, "Constructing driver:", err)
 		return
 	}
 

--- a/volmaster/volume.go
+++ b/volmaster/volume.go
@@ -33,7 +33,7 @@ func (dc *DaemonConfig) createVolume(policy *config.Policy, config *config.Volum
 		return storage.DriverOptions{}, err
 	}
 
-	driver, err := backend.NewCRUDDriver(dc.Global.Backend)
+	driver, err := backend.NewCRUDDriver(config.Backend)
 	if err != nil {
 		return storage.DriverOptions{}, err
 	}
@@ -61,7 +61,7 @@ func (dc *DaemonConfig) formatVolume(config *config.Volume, do storage.DriverOpt
 		return err
 	}
 
-	driver, err := backend.NewCRUDDriver(dc.Global.Backend)
+	driver, err := backend.NewCRUDDriver(config.Backend)
 	if err != nil {
 		return err
 	}
@@ -71,7 +71,7 @@ func (dc *DaemonConfig) formatVolume(config *config.Volume, do storage.DriverOpt
 }
 
 func (dc *DaemonConfig) existsVolume(config *config.Volume) (bool, error) {
-	driver, err := backend.NewCRUDDriver(dc.Global.Backend)
+	driver, err := backend.NewCRUDDriver(config.Backend)
 	if err != nil {
 		return false, err
 	}
@@ -88,7 +88,7 @@ func (dc *DaemonConfig) existsVolume(config *config.Volume) (bool, error) {
 }
 
 func (dc *DaemonConfig) removeVolume(config *config.Volume, timeout time.Duration) error {
-	driver, err := backend.NewCRUDDriver(dc.Global.Backend)
+	driver, err := backend.NewCRUDDriver(config.Backend)
 	if err != nil {
 		return err
 	}

--- a/volplugin/utils.go
+++ b/volplugin/utils.go
@@ -49,7 +49,7 @@ func (dc *DaemonConfig) structsVolumeName(uc *unmarshalledConfig) (storage.Mount
 		return nil, nil, driverOpts, err
 	}
 
-	driver, err := backend.NewMountDriver(dc.Global.Backend, dc.Global.MountPath)
+	driver, err := backend.NewMountDriver(volConfig.Backend, dc.Global.MountPath)
 	if err != nil {
 		return nil, nil, driverOpts, errored.Errorf("loading driver").Combine(err)
 	}


### PR DESCRIPTION
This implements a null (that is, no operations at all) driver suitable for use in production. it will be the foundation of the lack of a CRUD or snapshot system for NFS operations.

This also makes the backend dependent now on the volume instead of the global, which was removed. This is the next step towards multiple backends.