### PR TITLE
Vagrantfile: bump Docker to 1.11.1

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -56,7 +56,7 @@ ansible_provision = proc do |ansible|
 
   # In a production deployment, these should be secret
   ansible.extra_vars = {
-    docker_version: "1.11.0",
+    docker_version: "1.11.1",
     swarm_bootstrap_node_name: "mon0",
     docker_device: "/dev/sdb",
     etcd_peers_group: 'volplugin-test',


### PR DESCRIPTION
This bumps Docker to 1.11.1. I've run the tests and it's all passing.