### PR TITLE
Lock free operation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ docker-push: docker
 
 run: build
 	vagrant ssh mon0 -c 'volcli global upload < /testdata/globals/global1.json'
-	set -xe; for i in $$(seq 0 $$(($$(vagrant status | grep -v "not running" | grep -c running) - 2))); do vagrant ssh mon$$i -c 'cd $(GUESTGOPATH) && make run-volplugin run-volmaster'; done
+	set -e; for i in $$(seq 0 $$(($$(vagrant status | grep -v "not running" | grep -c running) - 2))); do vagrant ssh mon$$i -c 'cd $(GUESTGOPATH) && make run-volplugin run-volmaster'; done
 	vagrant ssh mon0 -c 'cd $(GUESTGOPATH) && make run-volsupervisor'
 
 run-etcd:

--- a/config/merge_test.go
+++ b/config/merge_test.go
@@ -11,6 +11,7 @@ func (s *configSuite) TestMerge(c *C) {
 		"snapshots":           "false",
 		"snapshots.frequency": "10m",
 		"snapshots.keep":      "20",
+		"unlocked":            "true",
 	}
 
 	c.Assert(mergeOpts(p, opts), IsNil)
@@ -20,4 +21,5 @@ func (s *configSuite) TestMerge(c *C) {
 	c.Assert(p.RuntimeOptions.UseSnapshots, Equals, false)
 	c.Assert(p.RuntimeOptions.Snapshot.Keep, Equals, uint(20))
 	c.Assert(p.RuntimeOptions.Snapshot.Frequency, Equals, "10m")
+	c.Assert(p.Unlocked, Equals, true)
 }

--- a/config/policy.go
+++ b/config/policy.go
@@ -14,6 +14,7 @@ import (
 // information for items such as pool and volume configuration.
 type Policy struct {
 	Name           string            `json:"name"`
+	Unlocked       bool              `json:"unlocked,omitempty" merge:"unlocked"`
 	CreateOptions  CreateOptions     `json:"create"`
 	RuntimeOptions RuntimeOptions    `json:"runtime"`
 	DriverOptions  map[string]string `json:"driver"`
@@ -92,7 +93,7 @@ func (c *Client) GetPolicy(name string) (*Policy, error) {
 		return nil, err
 	}
 
-	tc := &Policy{}
+	tc := NewPolicy()
 	if err := json.Unmarshal([]byte(resp.Node.Value), tc); err != nil {
 		return nil, err
 	}

--- a/config/volume.go
+++ b/config/volume.go
@@ -22,6 +22,7 @@ import (
 type Volume struct {
 	PolicyName     string            `json:"policy"`
 	VolumeName     string            `json:"name"`
+	Unlocked       bool              `json:"unlocked,omitempty" merge:"unlocked"`
 	DriverOptions  map[string]string `json:"driver"`
 	MountSource    string            `json:"mount" merge:"mount"`
 	CreateOptions  CreateOptions     `json:"create"`
@@ -111,6 +112,7 @@ func (c *Client) CreateVolume(rc RequestCreate) (*Volume, error) {
 		DriverOptions:  resp.DriverOptions,
 		CreateOptions:  resp.CreateOptions,
 		RuntimeOptions: resp.RuntimeOptions,
+		Unlocked:       resp.Unlocked,
 		PolicyName:     rc.Policy,
 		VolumeName:     rc.Volume,
 		MountSource:    mount,

--- a/lock/lock.go
+++ b/lock/lock.go
@@ -23,6 +23,10 @@ var (
 
 	// ErrRemove is an error for when use locks cannot be removed
 	ErrRemove = errors.New("Could not remove use lock")
+
+	// Unlocked is a string indicating unlocked operation, this is typically used
+	// as a hostname for our locking system.
+	Unlocked = "-unlocked-"
 )
 
 const (

--- a/systemtests/init_test.go
+++ b/systemtests/init_test.go
@@ -24,6 +24,11 @@ func TestSystem(t *T) {
 		os.Exit(0)
 	}
 
+	if os.Getenv("DEBUG_TEST") != "" {
+		log.SetLevel(log.DebugLevel)
+		log.Debug("Debug logging enabled")
+	}
+
 	TestingT(t)
 }
 

--- a/systemtests/testdata/nfs/unlocked.json
+++ b/systemtests/testdata/nfs/unlocked.json
@@ -1,0 +1,11 @@
+{ 
+  "backends": {
+    "crud": "",
+    "mount": "nfs",
+    "snapshot": ""
+  },
+  "unlocked": true,
+  "driver": { },
+  "create": { },
+  "runtime": { }
+}

--- a/systemtests/volplugin_test.go
+++ b/systemtests/volplugin_test.go
@@ -12,6 +12,26 @@ import (
 	log "github.com/Sirupsen/logrus"
 )
 
+func (s *systemtestSuite) TestVolpluginLockFreeOperation(c *C) {
+	if !nfsDriver() {
+		c.Skip("Cannot run this test on any driver but NFS")
+		return
+	}
+
+	out, err := s.uploadIntent("policy1", "unlocked")
+	c.Assert(err, IsNil, Commentf(out))
+	c.Assert(s.createVolume("mon0", "policy1", "test", nil), IsNil)
+
+	out, err = s.dockerRun("mon0", false, true, "policy1/test", "sleep 10m")
+	c.Assert(err, IsNil, Commentf(out))
+
+	out, err = s.dockerRun("mon1", false, true, "policy1/test", "sleep 10m")
+	c.Assert(err, IsNil, Commentf(out))
+
+	out, err = s.dockerRun("mon2", false, true, "policy1/test", "sleep 10m")
+	c.Assert(err, IsNil, Commentf(out))
+}
+
 func (s *systemtestSuite) TestVolpluginVolmasterDown(c *C) {
 	c.Assert(stopVolmaster(s.vagrant.GetNode("mon0")), IsNil)
 	c.Assert(stopVolplugin(s.vagrant.GetNode("mon0")), IsNil)

--- a/volplugin/volplugin.go
+++ b/volplugin/volplugin.go
@@ -240,7 +240,7 @@ func (dc *DaemonConfig) updateMounts() error {
 
 			log.Infof("Refreshing existing mount for %q", mount.Volume.Name)
 
-			_, err := dc.requestVolume(parts[0], parts[1])
+			vol, err := dc.requestVolume(parts[0], parts[1])
 			switch err {
 			case errVolumeNotFound:
 				log.Warnf("Volume %q not found in database, skipping")
@@ -250,9 +250,13 @@ func (dc *DaemonConfig) updateMounts() error {
 			}
 
 			payload := &config.UseMount{
-				Hostname: dc.Host,
 				Volume:   mount.Volume.Name,
 				Reason:   lock.ReasonMount,
+				Hostname: dc.Host,
+			}
+
+			if vol.Unlocked {
+				payload.Hostname = lock.Unlocked
 			}
 
 			if err := dc.Client.ReportMount(payload); err != nil {


### PR DESCRIPTION
This patch implements lock free operation as a toggle. What it does internally is replace the hostname for the exclusive lock on mount to a static string; this way any host can "take" the lock, but it still prevents mounted volumes from existing after a Remove call is issued (it will fail if there are any mounted).

It's not quite ready; there are still some tests to write and some cleanups to do. I was hoping for a preliminary review + CI pass before I move further, as the necessary code is here already.

@mapuri @unclejack @dseevr 