### PR TITLE
add version support in build target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,9 @@ run-volmaster:
 	sudo -E nohup bash -c '$(GUESTBINPATH)/volmaster &>/tmp/volmaster.log &'
 
 run-build: 
-	GOGC=1000 go install -v ./volcli/volcli/ ./volplugin/volplugin/ ./volmaster/volmaster/ ./volsupervisor/volsupervisor/
+	GOGC=1000 go install -v \
+		 -ldflags '-X main.version=$(if $(BUILD_VERSION),$(BUILD_VERSION),devbuild)' \
+		 ./volcli/volcli/ ./volplugin/volplugin/ ./volmaster/volmaster/ ./volsupervisor/volsupervisor/
 	cp /opt/golang/bin/* /tmp/bin
 
 system-test: build
@@ -135,8 +137,9 @@ TAR_FILENAME := $(NAME)-$(VERSION).$(TAR_EXT)
 TAR_LOC := .
 TAR_FILE := $(TAR_LOC)/$(TAR_FILENAME)
 
-tar: clean-tar build
+tar: clean-tar
 	@echo "v0.0.0-`date -u +%m-%d-%Y.%H-%M-%S.UTC`" > $(VERSION_FILE)
+	@BUILD_VERSION=$(VERSION) make build
 	@tar -jcf $(TAR_FILE) -C ${PWD}/bin volcli volmaster volplugin volsupervisor -C ${PWD} contrib/completion/bash/volcli
 
 clean-tar:

--- a/volcli/volcli/cli.go
+++ b/volcli/volcli/cli.go
@@ -8,10 +8,13 @@ import (
 	"github.com/contiv/volplugin/volcli"
 )
 
+// version is provided by build
+var version = ""
+
 func main() {
 	app := cli.NewApp()
 
-	app.Version = ""
+	app.Version = version
 	app.Flags = volcli.GlobalFlags
 	app.Usage = "Command volplugin and ceph infrastructure"
 	app.ArgsUsage = "[subcommand] [arguments]"

--- a/volmaster/volmaster/cli.go
+++ b/volmaster/volmaster/cli.go
@@ -12,6 +12,9 @@ import (
 	"github.com/codegangsta/cli"
 )
 
+// version is provided by build
+var version = ""
+
 func start(ctx *cli.Context) {
 	cfg, err := config.NewClient(ctx.String("prefix"), ctx.StringSlice("etcd"))
 	if err != nil {
@@ -29,7 +32,7 @@ func start(ctx *cli.Context) {
 
 func main() {
 	app := cli.NewApp()
-	app.Version = ""
+	app.Version = version
 	app.Usage = "Control many volplugins"
 	app.Action = start
 	app.Flags = []cli.Flag{

--- a/volplugin/volplugin/cli.go
+++ b/volplugin/volplugin/cli.go
@@ -10,6 +10,9 @@ import (
 
 var host string
 
+// version is provided by build
+var version = ""
+
 func init() {
 	var err error
 	host, err = os.Hostname()
@@ -20,7 +23,7 @@ func init() {
 
 func main() {
 	app := cli.NewApp()
-	app.Version = ""
+	app.Version = version
 	app.Usage = "Mount and manage Ceph RBD for containers"
 	app.Flags = []cli.Flag{
 		cli.StringFlag{

--- a/volsupervisor/volsupervisor/main.go
+++ b/volsupervisor/volsupervisor/main.go
@@ -10,6 +10,9 @@ import (
 
 var host string
 
+// version is provided by build
+var version = ""
+
 func init() {
 	var err error
 	host, err = os.Hostname()
@@ -20,7 +23,7 @@ func init() {
 
 func main() {
 	app := cli.NewApp()
-	app.Version = ""
+	app.Version = version
 	app.Usage = "Control many volplugins"
 	app.Action = volsupervisor.Daemon
 	app.Flags = []cli.Flag{


### PR DESCRIPTION
this let's us pass the version string from release CI to the built binaries thereby tying the binaries downloaded from github to respective releases.

Also it enables us to push versioned volplugin container images (with every github release) that we can use for setting up volplugin in our ansible. This will be done is a subsequent PR.

/cc @erikh @dseevr @unclejack