### PR TITLE
Several issues with copying snapshots

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,13 +63,13 @@ unit-test:
 	vagrant ssh mon0 -c 'sudo -i sh -c "cd $(GUESTGOPATH); TESTRUN="${TESTRUN}" make unit-test-host"'
 
 unit-test-host: golint-host govet-host
-	go list ./... | grep -v vendor | HOST_TEST=1 GOGC=1000 xargs -I{} go test -v '{}' -coverprofile=$(GUESTPREFIX)/src/{}/cover.out -check.v -run "${TESTRUN}"
+	go list ./... | grep -v vendor | HOST_TEST=1 GOGC=1000 xargs -I{} go test -v '{}' -coverprofile=$(GUESTPREFIX)/src/{}/cover.out -check.v -check.f "${TESTRUN}"
 
 unit-test-nocoverage:
 	vagrant ssh mon0 -c 'sudo -i sh -c "cd $(GUESTGOPATH); TESTRUN="${TESTRUN}" make unit-test-nocoverage-host"'
 
 unit-test-nocoverage-host: golint-host govet-host
-	HOST_TEST=1 GOGC=1000 go test -v -run "${TESTRUN}" ./... -check.v
+	HOST_TEST=1 GOGC=1000 go test -v ./... -check.v -check.f "${TESTRUN}"
 
 build: golint govet
 	vagrant ssh mon0 -c 'sudo -i sh -c "cd $(GUESTGOPATH); make run-build"'
@@ -109,7 +109,7 @@ run-build:
 	cp /opt/golang/bin/* /tmp/bin
 
 system-test: build
-	@./build/scripts/systemtests.sh
+	@TESTRUN="${TESTRUN}" ./build/scripts/systemtests.sh
 
 system-test-big:
 	BIG=1 make system-test

--- a/build/scripts/systemtests.sh
+++ b/build/scripts/systemtests.sh
@@ -10,5 +10,5 @@ fi
 for i in ceph nfs
 do
   echo running ${i}-driver tests...
-  USE_DRIVER="${i}" go test -v -timeout 240m ./systemtests -check.v
+  USE_DRIVER="${i}" go test -v -timeout 240m ./systemtests -check.v -check.f "${TESTRUN}"
 done

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -2,6 +2,7 @@ package errors
 
 import "github.com/contiv/errored"
 
+// service-level errors
 var (
 	// Exists is used to exit in situations where duplicated data would be written.
 	Exists = errored.New("Already exists")
@@ -20,6 +21,22 @@ var (
 	VolmasterRequest = errored.New("Making request to volmaster")
 )
 
+// storage-level errors
+var (
+	// RateLimit is used when applying rate limiting.
+	RateLimit = errored.New("Applying rate limiting configuration")
+
+	// MountPath is used when configuring the mount path.
+	MountPath = errored.New("Calculating mount path")
+
+	// SnapshotProtect is used when protecting snapshots for a copy fail.
+	SnapshotProtect = errored.New("Protecting snapshot")
+
+	// SnapshotCopy is used when copying snapshots to volumes fail.
+	SnapshotCopy = errored.New("Copying snapshot to volume")
+)
+
+// protocol-level errors
 var (
 	// UnmarshalRequest is used when a request failed to decode.
 	UnmarshalRequest = errored.New("Unmarshaling Request")
@@ -96,8 +113,6 @@ var (
 	PublishMount = errored.New("Could not publish mount information")
 	// GetMount is used when retrieving mounts.
 	GetMount = errored.New("Retrieving mount")
-	// MountPath is used when configuring the mount path.
-	MountPath = errored.New("Calculating mount path")
 	// MountFailed is used when mounts fail.
 	MountFailed = errored.New("Mount failed")
 	// UnmountFailed is used when unmounts fail.
@@ -110,7 +125,4 @@ var (
 
 	// ReadBody is used when reading the request body.
 	ReadBody = errored.New("Reading request body")
-
-	// RateLimit is used when applying rate limiting.
-	RateLimit = errored.New("Applying rate limiting configuration")
 )

--- a/storage/backend/ceph/ceph.go
+++ b/storage/backend/ceph/ceph.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/contiv/errored"
 	"github.com/contiv/executor"
+	"github.com/contiv/volplugin/errors"
 	"github.com/contiv/volplugin/storage"
 
 	log "github.com/Sirupsen/logrus"
@@ -397,7 +398,11 @@ func (c *Driver) CopySnapshot(do storage.DriverOptions, snapName, newName string
 	cmd := exec.Command("rbd", "snap", "protect", intOrigName, "--snap", snapName, "--pool", do.Volume.Params["pool"])
 	er, err := runWithTimeout(cmd, do.Timeout)
 
+	// EBUSY indicates that the snapshot is already protected.
 	if err != nil && er.ExitStatus != 0 && er.ExitStatus != int(unix.EBUSY) {
+		if er.ExitStatus == int(unix.EEXIST) {
+			err = errored.Errorf("Volume %q or snapshot name %q already exists. Snapshots cannot share the same name as the target volume.", do.Volume.Name, snapName).Combine(errors.Exists).Combine(errors.SnapshotProtect)
+		}
 		errChan <- err
 		return err
 	}
@@ -405,16 +410,23 @@ func (c *Driver) CopySnapshot(do storage.DriverOptions, snapName, newName string
 	defer func() {
 		select {
 		case err := <-errChan:
-			log.Warnf("Error received while copying snapshot: %v. Attempting to cleanup.", err)
-			cmd = exec.Command("rbd", "rm", intNewName, "--pool", do.Volume.Params["pool"])
-			if er, err := runWithTimeout(cmd, do.Timeout); err != nil || er.ExitStatus != 0 {
-				log.Errorf("Error encountered removing new volume %q for volume %q, snapshot %q: %v, %v", intNewName, intOrigName, snapName, err, er.Stderr)
-				return
+			newerr, ok := err.(*errored.Error)
+			if ok && newerr.Contains(errors.SnapshotCopy) {
+				log.Warnf("Error received while copying snapshot %q: %v. Attempting to cleanup... Snapshot %q may still be protected!", do.Volume.Name, err, snapName)
+				cmd = exec.Command("rbd", "rm", intNewName, "--pool", do.Volume.Params["pool"])
+				if er, err := runWithTimeout(cmd, do.Timeout); err != nil || er.ExitStatus != 0 {
+					log.Errorf("Error encountered removing new volume %q for volume %q, snapshot %q: %v, %v", intNewName, intOrigName, snapName, err, er.Stderr)
+					return
+				}
 			}
-			cmd := exec.Command("rbd", "snap", "unprotect", intOrigName, "--snap", snapName, "--pool", do.Volume.Params["pool"])
-			if er, err := runWithTimeout(cmd, do.Timeout); err != nil || er.ExitStatus != 0 {
-				log.Errorf("Error encountered unprotecting new volume %q for volume %q, snapshot %q: %v, %v", newName, intOrigName, snapName, err, er.Stderr)
-				return
+
+			if ok && newerr.Contains(errors.SnapshotProtect) {
+				log.Warnf("Error received protecting snapshot %q: %v. Attempting to cleanup.", do.Volume.Name, err)
+				cmd := exec.Command("rbd", "snap", "unprotect", intOrigName, "--snap", snapName, "--pool", do.Volume.Params["pool"])
+				if er, err := runWithTimeout(cmd, do.Timeout); err != nil || er.ExitStatus != 0 {
+					log.Errorf("Error encountered unprotecting new volume %q for volume %q, snapshot %q: %v, %v", newName, intOrigName, snapName, err, er.Stderr)
+					return
+				}
 			}
 		default:
 		}
@@ -422,14 +434,23 @@ func (c *Driver) CopySnapshot(do storage.DriverOptions, snapName, newName string
 
 	cmd = exec.Command("rbd", "clone", intOrigName, intNewName, "--snap", snapName, "--pool", do.Volume.Params["pool"])
 	er, err = runWithTimeout(cmd, do.Timeout)
-	if err != nil {
-		errChan <- err
-		return err
+	if err != nil && er.ExitStatus == 0 {
+		var err2 *errored.Error
+		var ok bool
+
+		err2, ok = err.(*errored.Error)
+		if !ok {
+			err2 = errored.New(err.Error())
+		}
+		errChan <- err2.Combine(errors.SnapshotCopy)
+		return err2
 	}
 
 	if er.ExitStatus != 0 {
-		newerr := errored.Errorf("Cloning snapshot to volume (volume %q, snapshot %q): %v", intOrigName, snapName, err)
-		errChan <- newerr
+		newerr := errored.Errorf("Cloning snapshot to volume (volume %q, snapshot %q): %v", intOrigName, snapName, err).Combine(errors.SnapshotCopy).Combine(errors.SnapshotProtect)
+		if er.ExitStatus != int(unix.EEXIST) {
+			errChan <- newerr
+		}
 		return err
 	}
 

--- a/storage/backend/ceph/internals.go
+++ b/storage/backend/ceph/internals.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"golang.org/x/net/context"
+	"golang.org/x/sys/unix"
 
 	"github.com/contiv/errored"
 	"github.com/contiv/executor"
@@ -105,7 +106,7 @@ retry:
 			er, err := runWithTimeout(cmd, do.Timeout)
 			if retries < 10 && (err != nil || er.ExitStatus != 0) {
 				log.Errorf("Could not unmap volume %q (device %q): %v (%v) (%v)", intName, rbd.Device, er, err, er.Stderr)
-				if er.ExitStatus == 16 {
+				if er.ExitStatus == int(unix.EBUSY) {
 					log.Errorf("Retrying to unmap volume %q (device %q)...", intName, rbd.Device)
 					time.Sleep(100 * time.Millisecond)
 					retries++

--- a/volmaster/daemon.go
+++ b/volmaster/daemon.go
@@ -449,12 +449,6 @@ func (d *DaemonConfig) handleCopy(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	uc := &config.UseMount{
-		Volume:   volConfig.String(),
-		Reason:   lock.ReasonCopy,
-		Hostname: host,
-	}
-
 	snapUC := &config.UseSnapshot{
 		Volume: volConfig.String(),
 		Reason: lock.ReasonCopy,
@@ -471,7 +465,7 @@ func (d *DaemonConfig) handleCopy(w http.ResponseWriter, r *http.Request) {
 		Reason: lock.ReasonCopy,
 	}
 
-	err = lock.NewDriver(d.Config).ExecuteWithMultiUseLock([]config.UseLocker{newUC, newSnapUC, uc, snapUC}, d.Global.Timeout, func(ld *lock.Driver, ucs []config.UseLocker) error {
+	err = lock.NewDriver(d.Config).ExecuteWithMultiUseLock([]config.UseLocker{newUC, newSnapUC, snapUC}, d.Global.Timeout, func(ld *lock.Driver, ucs []config.UseLocker) error {
 		if err := d.Config.PublishVolume(newVolConfig); err != nil {
 			return err
 		}


### PR DESCRIPTION
* We failed to acquire a lock when the volume was mounted, which timed out preventing the copy and a lengthy round trip on the error. The code was adjusted to remove the requirement that the volume would not be mounted.
* Several bugs in the ceph storage driver around copying were fixed:
  * when EBUSY is returned during a snapshot volume protect, *do not* fail. It is simply because the snapshot  is already protected.
  * when EEXIST is returned during any copy operation, the volume named would be cleaned up as a part of the healing process, which would in turn remove the volume if it exists. Previously, this would clean up any named volume.

Fixes #294 /cc @vishal-j 