### PR TITLE
*: Remove config.RequestCreate; normalize with config.Request

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -29,16 +29,9 @@ var defaultPaths = []string{rootVolume, rootUse, rootPolicy, rootSnapshots}
 // Request provides a request structure for communicating with the
 // volmaster.
 type Request struct {
-	Volume  string `json:"volume"`
-	Policy  string `json:"policy"`
-	Options map[string]string
-}
-
-// RequestCreate provides a request structure for creating new volumes.
-type RequestCreate struct {
-	Policy string            `json:"policy"`
-	Volume string            `json:"volume"`
-	Opts   map[string]string `json:"opts"`
+	Volume  string            `json:"volume"`
+	Policy  string            `json:"policy"`
+	Options map[string]string `json:"options"`
 }
 
 // Client is the top-level struct for communicating with the intent store.

--- a/config/volume.go
+++ b/config/volume.go
@@ -83,7 +83,7 @@ func (c *Client) PublishVolumeRuntime(vo *Volume, ro RuntimeOptions) error {
 
 // CreateVolume sets the appropriate config metadata for a volume creation
 // operation, and returns the Volume that was copied in.
-func (c *Client) CreateVolume(rc RequestCreate) (*Volume, error) {
+func (c *Client) CreateVolume(rc Request) (*Volume, error) {
 	resp, err := c.GetPolicy(rc.Policy)
 	if err != nil {
 		return nil, err
@@ -91,12 +91,12 @@ func (c *Client) CreateVolume(rc RequestCreate) (*Volume, error) {
 
 	var mount string
 
-	if rc.Opts != nil {
-		mount = rc.Opts["mount"]
-		delete(rc.Opts, "mount")
+	if rc.Options != nil {
+		mount = rc.Options["mount"]
+		delete(rc.Options, "mount")
 	}
 
-	if err := mergeOpts(resp, rc.Opts); err != nil {
+	if err := mergeOpts(resp, rc.Options); err != nil {
 		return nil, err
 	}
 

--- a/config/volume_test.go
+++ b/config/volume_test.go
@@ -107,7 +107,7 @@ func (s *configSuite) TestWatchVolumes(c *C) {
 	volumeChan := make(chan *watch.Watch)
 	s.tlc.WatchVolumeRuntimes(volumeChan)
 
-	vol, err := s.tlc.CreateVolume(RequestCreate{Policy: "policy1", Volume: "test"})
+	vol, err := s.tlc.CreateVolume(Request{Policy: "policy1", Volume: "test"})
 	c.Assert(err, IsNil)
 	c.Assert(s.tlc.PublishVolume(vol), IsNil)
 	vol2 := <-volumeChan
@@ -122,10 +122,10 @@ func (s *configSuite) TestVolumeCRUD(c *C) {
 	volumeNames := []string{"baz", "quux"}
 	sort.Strings(volumeNames) // lazy
 
-	_, err := s.tlc.CreateVolume(RequestCreate{})
+	_, err := s.tlc.CreateVolume(Request{})
 	c.Assert(err, NotNil)
 
-	_, err = s.tlc.CreateVolume(RequestCreate{Policy: "Doesn'tExist"})
+	_, err = s.tlc.CreateVolume(Request{Policy: "Doesn'tExist"})
 	c.Assert(err, NotNil)
 
 	// populate the policies so the next few tests don't give false positives
@@ -133,10 +133,10 @@ func (s *configSuite) TestVolumeCRUD(c *C) {
 		c.Assert(s.tlc.PublishPolicy(policy, testPolicies["basic"]), IsNil)
 	}
 
-	_, err = s.tlc.CreateVolume(RequestCreate{Policy: "foo", Volume: "bar", Opts: map[string]string{"quux": "derp"}})
+	_, err = s.tlc.CreateVolume(Request{Policy: "foo", Volume: "bar", Options: map[string]string{"quux": "derp"}})
 	c.Assert(err, NotNil)
 
-	_, err = s.tlc.CreateVolume(RequestCreate{Policy: "foo", Volume: ""})
+	_, err = s.tlc.CreateVolume(Request{Policy: "foo", Volume: ""})
 	c.Assert(err, NotNil)
 
 	_, err = s.tlc.GetVolume("foo", "bar")
@@ -147,7 +147,7 @@ func (s *configSuite) TestVolumeCRUD(c *C) {
 
 	for _, policy := range policyNames {
 		for _, volume := range volumeNames {
-			vcfg, err := s.tlc.CreateVolume(RequestCreate{Policy: policy, Volume: volume, Opts: map[string]string{"filesystem": ""}})
+			vcfg, err := s.tlc.CreateVolume(Request{Policy: policy, Volume: volume, Options: map[string]string{"filesystem": ""}})
 			c.Assert(err, IsNil)
 			c.Assert(s.tlc.PublishVolume(vcfg), IsNil)
 			c.Assert(s.tlc.PublishVolume(vcfg), Equals, errors.Exists)
@@ -209,7 +209,7 @@ func (s *configSuite) TestVolumeCRUD(c *C) {
 
 func (s *configSuite) TestVolumeRuntime(c *C) {
 	c.Assert(s.tlc.PublishPolicy("policy1", testPolicies["basic"]), IsNil)
-	vol, err := s.tlc.CreateVolume(RequestCreate{Policy: "policy1", Volume: "test"})
+	vol, err := s.tlc.CreateVolume(Request{Policy: "policy1", Volume: "test"})
 	c.Assert(err, IsNil)
 	c.Assert(s.tlc.PublishVolume(vol), IsNil)
 	runtime := vol.RuntimeOptions
@@ -229,7 +229,7 @@ func (s *configSuite) TestVolumeRuntime(c *C) {
 
 func (s *configSuite) TestToDriverOptions(c *C) {
 	c.Assert(s.tlc.PublishPolicy("policy1", testPolicies["basic"]), IsNil)
-	vol, err := s.tlc.CreateVolume(RequestCreate{Policy: "policy1", Volume: "test"})
+	vol, err := s.tlc.CreateVolume(Request{Policy: "policy1", Volume: "test"})
 	c.Assert(err, IsNil)
 
 	do, err := vol.ToDriverOptions(1)

--- a/lock/lock_test.go
+++ b/lock/lock_test.go
@@ -42,7 +42,7 @@ func (s *lockSuite) SetUpTest(c *C) {
 }
 
 func (s *lockSuite) TestExecuteWithUseLock(c *C) {
-	vc, err := s.tlc.CreateVolume(config.RequestCreate{Policy: "policy", Volume: "foo"})
+	vc, err := s.tlc.CreateVolume(config.Request{Policy: "policy", Volume: "foo"})
 	c.Assert(err, IsNil)
 	uc := &config.UseMount{
 		Volume:   vc.String(),
@@ -101,7 +101,7 @@ func (s *lockSuite) TestExecuteWithUseLock(c *C) {
 }
 
 func (s *lockSuite) TestExecuteWithMultiUseLock(c *C) {
-	vc, err := s.tlc.CreateVolume(config.RequestCreate{Policy: "policy", Volume: "foo"})
+	vc, err := s.tlc.CreateVolume(config.Request{Policy: "policy", Volume: "foo"})
 	c.Assert(err, IsNil)
 	um := &config.UseMount{
 		Volume:   vc.String(),

--- a/volcli/commands.go
+++ b/volcli/commands.go
@@ -188,14 +188,26 @@ var Commands = []cli.Command{
 				Usage:       "List uses",
 				Description: "List the uses the volmaster knows about, in newline-delimited form.",
 				ArgsUsage:   "",
-				Action:      UseList,
+				Flags: []cli.Flag{
+					cli.BoolFlag{
+						Name:  "snapshots",
+						Usage: "List snapshots instead of mounts",
+					},
+				},
+				Action: UseList,
 			},
 			{
 				Name:        "get",
 				Usage:       "Get use info",
 				Description: "Obtains the information on a specified use. Requires that you know the policy and image name.",
 				ArgsUsage:   "[policy name]/[volume name]",
-				Action:      UseGet,
+				Flags: []cli.Flag{
+					cli.BoolFlag{
+						Name:  "snapshot",
+						Usage: "Get the snapshot use instead of a mount",
+					},
+				},
+				Action: UseGet,
 			},
 			{
 				Name:        "force-remove",

--- a/volcli/volcli.go
+++ b/volcli/volcli.go
@@ -704,7 +704,13 @@ func useList(ctx *cli.Context) (bool, error) {
 		return false, err
 	}
 
-	uses, err := cfg.ListUses("mount")
+	var uses []string
+	if ctx.Bool("snapshots") {
+		uses, err = cfg.ListUses("snapshot")
+	} else {
+		uses, err = cfg.ListUses("mount")
+	}
+
 	if err != nil {
 		return false, err
 	}
@@ -741,13 +747,19 @@ func useGet(ctx *cli.Context) (bool, error) {
 		VolumeName: volume,
 	}
 
-	mount := &config.UseMount{}
+	var ul config.UseLocker
 
-	if err := cfg.GetUse(mount, vc); err != nil {
+	if ctx.Bool("snapshot") {
+		ul = &config.UseSnapshot{}
+	} else {
+		ul = &config.UseMount{}
+	}
+
+	if err := cfg.GetUse(ul, vc); err != nil {
 		return false, err
 	}
 
-	content, err := ppJSON(mount)
+	content, err := ppJSON(ul)
 	if err != nil {
 		return false, err
 	}

--- a/volcli/volcli.go
+++ b/volcli/volcli.go
@@ -312,10 +312,10 @@ func volumeCreate(ctx *cli.Context) (bool, error) {
 		opts[pair[0]] = pair[1]
 	}
 
-	tc := &config.RequestCreate{
-		Policy: policy,
-		Volume: volume,
-		Opts:   opts,
+	tc := &config.Request{
+		Policy:  policy,
+		Volume:  volume,
+		Options: opts,
 	}
 
 	content, err := json.Marshal(tc)

--- a/volmaster/daemon.go
+++ b/volmaster/daemon.go
@@ -770,7 +770,7 @@ func (d *DaemonConfig) handleCreate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var req config.RequestCreate
+	var req config.Request
 
 	if err := json.Unmarshal(content, &req); err != nil {
 		httpError(w, errors.UnmarshalRequest.Combine(err))

--- a/volplugin/utils.go
+++ b/volplugin/utils.go
@@ -170,7 +170,7 @@ func (dc *DaemonConfig) requestRemove(policy, name string) error {
 }
 
 func (dc *DaemonConfig) requestCreate(policyName, name string, opts map[string]string) error {
-	content, err := json.Marshal(config.RequestCreate{Policy: policyName, Volume: name, Opts: opts})
+	content, err := json.Marshal(config.Request{Policy: policyName, Volume: name, Options: opts})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This makes the API considerably simpler by making most requests use the same structure. Additionally, I have lower-cased all properties so they are easier to use.

Fixes #298