### PR TITLE
Fixes for same-host multi-mount mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ run-build:
 		 ./volcli/volcli/ ./volplugin/volplugin/ ./volmaster/volmaster/ ./volsupervisor/volsupervisor/
 	cp /opt/golang/bin/* /tmp/bin
 
-system-test: build
+system-test: run 
 	@TESTRUN="${TESTRUN}" ./build/scripts/systemtests.sh
 
 system-test-big:

--- a/systemtests/init_test.go
+++ b/systemtests/init_test.go
@@ -99,6 +99,7 @@ func (s *systemtestSuite) SetUpSuite(c *C) {
 	c.Assert(s.clearContainers(), IsNil)
 	c.Assert(s.restartDocker(), IsNil)
 	c.Assert(s.pullDebian(), IsNil)
+	c.Assert(s.rebootstrap(), IsNil)
 
 	out, err := s.uploadIntent("policy1", "policy1")
 	c.Assert(err, IsNil, Commentf("output: %s", out))

--- a/volplugin/mountcount.go
+++ b/volplugin/mountcount.go
@@ -1,6 +1,8 @@
 package volplugin
 
 import (
+	"fmt"
+
 	log "github.com/Sirupsen/logrus"
 )
 
@@ -19,5 +21,9 @@ func (dc *DaemonConfig) decreaseMount(mp string) int {
 
 	dc.mountCount[mp]--
 	log.Debugf("Mount count decreased to %d for %q", dc.mountCount[mp], mp)
+	if dc.mountCount[mp] < 0 {
+		panic(fmt.Sprintf("Assertion failed while tracking unmount: mount count for %q is less than 0", mp))
+	}
+
 	return dc.mountCount[mp]
 }


### PR DESCRIPTION
This fixes a bug in the mount counting code that would cause it to go negative. You would have to acquire volumes very fast on multiple hosts and then it to happen, which is a significant edge case.

To prevent future bugs in the future like this, I have added some code to panic the daemon if the mount count goes negative. We can do serious damage if we don't, as the counting system gets off and duplicate maps/mounts happen.