### PR TITLE
Global driver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,6 @@ build: golint govet
 	vagrant ssh mon0 -c 'sudo -i sh -c "cd $(GUESTGOPATH); make run-build"'
 	if [ ! -n "$$DEMO" ]; then for i in mon1 mon2; do vagrant ssh $$i -c 'sudo sh -c "pkill volplugin; pkill volmaster; pkill volsupervisor; mkdir -p /opt/golang/bin; cp /tmp/bin/* /opt/golang/bin"'; done; fi
 
-
 docker: run-build
 	docker build -t contiv/volplugin .
 
@@ -83,7 +82,7 @@ docker-push: docker
 	docker push contiv/volplugin
 
 run: build
-	set -e; for i in $$(seq 0 $$(($$(vagrant status | grep -v "not running" | grep -c running) - 2))); do vagrant ssh mon$$i -c 'cd $(GUESTGOPATH) && make run-volplugin run-volmaster'; done
+	set -e; for i in $$(seq 0 $$(($$(vagrant status | grep -cE 'mon.*running') - 1))); do vagrant ssh mon$$i -c 'cd $(GUESTGOPATH) && make run-volplugin run-volmaster'; done
 	vagrant ssh mon0 -c 'cd $(GUESTGOPATH) && make run-volsupervisor'
 	vagrant ssh mon0 -c 'volcli global upload < /testdata/globals/global1.json'
 

--- a/volplugin/handlers.go
+++ b/volplugin/handlers.go
@@ -389,6 +389,21 @@ func (dc *DaemonConfig) unmount(w http.ResponseWriter, r *http.Request) {
 	dc.returnMountPath(w, driver, driverOpts)
 }
 
+func (dc *DaemonConfig) capabilities(w http.ResponseWriter, r *http.Request) {
+	content, err := json.Marshal(map[string]map[string]string{
+		"Capabilities": map[string]string{
+			"Scope": "global",
+		},
+	})
+
+	if err != nil {
+		httpError(w, errors.UnmarshalRequest.Combine(err))
+		return
+	}
+
+	w.Write(content)
+}
+
 // Catchall for additional driver functions.
 func (dc *DaemonConfig) action(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()

--- a/volplugin/volplugin.go
+++ b/volplugin/volplugin.go
@@ -138,15 +138,16 @@ func (dc *DaemonConfig) Daemon() error {
 
 func (dc *DaemonConfig) configureRouter() *mux.Router {
 	var routeMap = map[string]func(http.ResponseWriter, *http.Request){
-		"/Plugin.Activate":      dc.activate,
-		"/Plugin.Deactivate":    dc.nilAction,
-		"/VolumeDriver.Create":  dc.create,
-		"/VolumeDriver.Remove":  dc.getPath, // we never actually remove through docker's interface.
-		"/VolumeDriver.List":    dc.list,
-		"/VolumeDriver.Get":     dc.get,
-		"/VolumeDriver.Path":    dc.getPath,
-		"/VolumeDriver.Mount":   dc.mount,
-		"/VolumeDriver.Unmount": dc.unmount,
+		"/Plugin.Activate":           dc.activate,
+		"/Plugin.Deactivate":         dc.nilAction,
+		"/VolumeDriver.Create":       dc.create,
+		"/VolumeDriver.Remove":       dc.getPath, // we never actually remove through docker's interface.
+		"/VolumeDriver.List":         dc.list,
+		"/VolumeDriver.Get":          dc.get,
+		"/VolumeDriver.Path":         dc.getPath,
+		"/VolumeDriver.Mount":        dc.mount,
+		"/VolumeDriver.Unmount":      dc.unmount,
+		"/VolumeDriver.Capabilities": dc.capabilities,
 	}
 
 	router := mux.NewRouter()


### PR DESCRIPTION
This implements the necessary API calls to present ourselves as a global driver to docker.

Necessary in Swarm 1.1 and up, and docker 1.12.