### PR TITLE
Vagrantfile: randomize the third octet of the subnet to allow for up to 255 development environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ docs/docs
 .DS_Store
 *.swp
 cscope.*
+subnet_assignment.state

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ stop:
 	make clean
 
 clean:
+	rm -f subnet_assignment.state
 	rm -f *.vdi
 	rm -f .vagrant/*.vmdk
 

--- a/vagrant_variables.yml
+++ b/vagrant_variables.yml
@@ -4,7 +4,9 @@
 vms: 3
 
 # SUBNET TO USE FOR THE VMS
-subnet: 192.168.24
+# The third octet will be randomly selected (and guaranteed not to be in use), and the fourth will always be 0
+subnet_prefix: 192.168.
+
 
 # MEMORY
 memory: 4096


### PR DESCRIPTION
Octet reservation is protected by locking so it’s safe to bring up many environments at the same time.

Addresses #319