### PR TITLE
Improve test performance

### DIFF
--- a/lock/lock.go
+++ b/lock/lock.go
@@ -169,10 +169,12 @@ retry:
 	if ttl != time.Duration(0) {
 		if err = d.Config.PublishUseWithTTL(uc, ttl, client.PrevExist); err != nil {
 			log.Debugf("Lock publish failed for %q with error: %v. Continuing.", uc, err)
-			if err.(*errored.Error).Contains(errors.NotExists) {
+			if er, ok := err.(*errored.Error); ok && er.Contains(errors.NotExists) {
 				if err = d.Config.PublishUseWithTTL(uc, ttl, client.PrevNoExist); err != nil {
 					log.Warnf("Could not acquire %q lock for %q: %v", uc.GetReason(), uc.GetVolume(), err)
 				}
+			} else if err != nil {
+				return err
 			}
 		}
 	} else {

--- a/systemtests/volume_test.go
+++ b/systemtests/volume_test.go
@@ -8,40 +8,32 @@ import (
 	. "gopkg.in/check.v1"
 )
 
-func (s *systemtestSuite) TestVolumeCreate(c *C) {
-	c.Assert(s.createVolumeHost("policy1", "mon0", nil), IsNil)
-}
-
-func (s *systemtestSuite) TestVolumeCreateMultiHost(c *C) {
-	for _, host := range []string{"mon0", "mon1", "mon2"} {
-		c.Assert(s.createVolumeHost("policy1", host, nil), IsNil)
-	}
-}
-
 func (s *systemtestSuite) TestVolumeCreateMultiHostCrossHostMount(c *C) {
 	if nullDriver() {
 		c.Skip("This driver does not support multi-host operation")
 		return
 	}
 
-	c.Assert(s.createVolume("mon0", "policy1", "test", nil), IsNil)
+	fqVolName := fqVolume("policy1", genRandomVolume())
 
-	_, err := s.dockerRun("mon0", false, false, "policy1/test", `sh -c "echo bar > /mnt/foo"`)
+	c.Assert(s.createVolume("mon0", fqVolName, nil), IsNil)
+
+	_, err := s.dockerRun("mon0", false, false, fqVolName, `sh -c "echo bar > /mnt/foo"`)
 	c.Assert(err, IsNil)
-	c.Assert(s.createVolume("mon1", "policy1", "test", nil), IsNil)
+	c.Assert(s.createVolume("mon1", fqVolName, nil), IsNil)
 
-	out, err := s.dockerRun("mon1", false, false, "policy1/test", `sh -c "cat /mnt/foo"`)
+	out, err := s.dockerRun("mon1", false, false, fqVolName, `sh -c "cat /mnt/foo"`)
 	c.Assert(err, IsNil)
 	c.Assert(strings.TrimSpace(out), Equals, "bar")
 
-	c.Assert(s.createVolume("mon1", "policy1", "test", nil), IsNil)
+	c.Assert(s.createVolume("mon1", fqVolName, nil), IsNil)
 
-	_, err = s.dockerRun("mon1", false, false, "policy1/test", `sh -c "echo quux > /mnt/foo"`)
+	_, err = s.dockerRun("mon1", false, false, fqVolName, `sh -c "echo quux > /mnt/foo"`)
 	c.Assert(err, IsNil)
 
-	c.Assert(s.createVolume("mon2", "policy1", "test", nil), IsNil)
+	c.Assert(s.createVolume("mon2", fqVolName, nil), IsNil)
 
-	out, err = s.dockerRun("mon2", false, false, "policy1/test", `sh -c "cat /mnt/foo"`)
+	out, err = s.dockerRun("mon2", false, false, fqVolName, `sh -c "cat /mnt/foo"`)
 	c.Assert(err, IsNil)
 	c.Assert(strings.TrimSpace(out), Equals, "quux")
 }
@@ -50,25 +42,28 @@ func (s *systemtestSuite) TestVolumeMultiPolicyCreate(c *C) {
 	_, err := s.uploadIntent("policy2", "policy2")
 	c.Assert(err, IsNil)
 
-	c.Assert(s.createVolume("mon0", "policy1", "test", nil), IsNil)
-	c.Assert(s.createVolume("mon0", "policy2", "test", nil), IsNil)
+	fqVolName := fqVolume("policy1", genRandomVolume())
+	fqVolName2 := fqVolume("policy2", genRandomVolume())
 
-	_, err = s.dockerRun("mon0", false, false, "policy1/test", `sh -c "echo foo > /mnt/bar"`)
+	c.Assert(s.createVolume("mon0", fqVolName, nil), IsNil)
+	c.Assert(s.createVolume("mon0", fqVolName2, nil), IsNil)
+
+	_, err = s.dockerRun("mon0", false, false, fqVolName, `sh -c "echo foo > /mnt/bar"`)
 	c.Assert(err, IsNil)
 
 	c.Assert(s.clearContainers(), IsNil)
 
-	_, err = s.dockerRun("mon0", false, false, "policy2/test", `sh -c "cat /mnt/bar"`)
+	_, err = s.dockerRun("mon0", false, false, fqVolName2, `sh -c "cat /mnt/bar"`)
 	c.Assert(err, NotNil)
 
 	c.Assert(s.clearContainers(), IsNil)
 
-	_, err = s.dockerRun("mon0", false, false, "policy2/test", `sh -c "echo bar > /mnt/foo"`)
+	_, err = s.dockerRun("mon0", false, false, fqVolName2, `sh -c "echo bar > /mnt/foo"`)
 	c.Assert(err, IsNil)
 
 	c.Assert(s.clearContainers(), IsNil)
 
-	_, err = s.dockerRun("mon0", false, false, "policy1/test", `sh -c "cat /mnt/foo"`)
+	_, err = s.dockerRun("mon0", false, false, fqVolName, `sh -c "cat /mnt/foo"`)
 	c.Assert(err, NotNil)
 }
 
@@ -78,17 +73,20 @@ func (s *systemtestSuite) TestVolumeMultiCreateThroughDocker(c *C) {
 		return
 	}
 
-	c.Assert(s.createVolume("mon0", "policy1", "test", nil), IsNil)
+	volName := genRandomVolume()
+	fqVolName := fqVolume("policy1", volName)
+
+	c.Assert(s.createVolume("mon0", fqVolName, nil), IsNil)
 
 	out, err := s.vagrant.GetNode("mon0").RunCommandWithOutput("sudo rbd ls")
 	c.Assert(err, IsNil)
-	c.Assert(strings.TrimSpace(out), Equals, "policy1.test")
+	c.Assert(strings.TrimSpace(out), Equals, "policy1."+volName)
 
 	c.Assert(s.vagrant.IterateNodes(func(node vagrantssh.TestbedNode) error {
-		return node.RunCommand("docker volume create -d volplugin --name policy1/test")
+		return node.RunCommand("docker volume create -d volplugin --name " + fqVolName)
 	}), IsNil)
 
 	c.Assert(s.vagrant.IterateNodes(func(node vagrantssh.TestbedNode) error {
-		return node.RunCommand("docker volume rm policy1/test")
+		return node.RunCommand("docker volume rm " + fqVolName)
 	}), IsNil)
 }


### PR DESCRIPTION
The volume CRUD primitives were lousy. I moved on @mapuri's randomized
containers patches and did the same for volumes. Because of a bug in docker
(see below) we cannot create the same volume twice in a short period of time
without hitting a cache bug:

docker/docker#24205 for more information.

This fix implements a cleaner API for managing volumes, and converts the whole
suite to use those features, including the randomized volume names.