### PR TITLE
apiserver,config: refactor Global configuration management (see below)

### DIFF
--- a/apiserver/daemon.go
+++ b/apiserver/daemon.go
@@ -493,7 +493,7 @@ func (d *DaemonConfig) handleCopy(w http.ResponseWriter, r *http.Request) {
 }
 
 func (d *DaemonConfig) handleGlobal(w http.ResponseWriter, r *http.Request) {
-	content, err := json.Marshal(d.Global)
+	content, err := json.Marshal(d.Global.Published())
 	if err != nil {
 		api.RESTHTTPError(w, errors.MarshalGlobal.Combine(err))
 		return

--- a/config/global_test.go
+++ b/config/global_test.go
@@ -11,15 +11,15 @@ func (s *configSuite) TestGlobal(c *C) {
 
 	global := &Global{
 		Debug:     true,
-		TTL:       10,
-		Timeout:   1,
+		TTL:       DefaultGlobalTTL,
+		Timeout:   DefaultTimeout,
 		MountPath: defaultMountPath,
 	}
 
 	c.Assert(s.tlc.PublishGlobal(global), IsNil)
 	global2, err := s.tlc.GetGlobal()
 	c.Assert(err, IsNil)
-	global.fixupParameters()
+	global = global.Canonical()
 	c.Assert(global, DeepEquals, global2)
 }
 
@@ -28,7 +28,7 @@ func (s *configSuite) TestGlobalEmpty(c *C) {
 	global, err := s.tlc.GetGlobal()
 	c.Assert(err, IsNil)
 
-	c.Assert(global, DeepEquals, &Global{
+	c.Assert(global.SetEmpty(), DeepEquals, &Global{
 		TTL:       DefaultGlobalTTL,
 		MountPath: defaultMountPath,
 		Timeout:   DefaultTimeout,
@@ -40,8 +40,8 @@ func (s *configSuite) TestGlobalWatch(c *C) {
 
 	global := &Global{
 		Debug:     true,
-		TTL:       10,
-		Timeout:   1,
+		TTL:       DefaultGlobalTTL,
+		Timeout:   DefaultTimeout,
 		MountPath: defaultMountPath,
 	}
 
@@ -52,6 +52,6 @@ func (s *configSuite) TestGlobalWatch(c *C) {
 	c.Assert(s.tlc.PublishGlobal(global), IsNil)
 	global2 := (<-activity).Config.(*Global)
 	c.Assert(global2, NotNil)
-	global.fixupParameters()
+	global2 = global2.Canonical()
 	c.Assert(global, DeepEquals, global2)
 }

--- a/systemtests/volcli_test.go
+++ b/systemtests/volcli_test.go
@@ -20,7 +20,7 @@ func (s *systemtestSuite) TestVolCLIEmptyGlobal(c *C) {
 	target := &config.Global{}
 
 	c.Assert(json.Unmarshal([]byte(out), target), IsNil, Commentf(out))
-	c.Assert(config.NewGlobalConfig(), DeepEquals, target, Commentf("%q %#v", out, target))
+	c.Assert(config.NewGlobalConfig().Published(), DeepEquals, target, Commentf("%q %#v", out, target))
 }
 
 func (s *systemtestSuite) TestVolCLIPolicy(c *C) {


### PR DESCRIPTION
Globals were pretty ugly in how they calculated parameters. They were stateful
and it was hard to manage between the different spots in the code.

I refactored it to use a stateless design with three new functions to set
parameters in a functional way. This way instead of passing around mutable
state, code can just ask for the type of parameters it needs.

Fixes #334 

/cc @melanietom 

Signed-off-by: Erik Hollensbe <github@hollensbe.org>