### PR TITLE
Makefile: turn off release builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,6 +137,9 @@ system-test: run
 system-test-big:
 	BIG=1 make system-test
 
+vendor-ansible:
+	git subtree pull --prefix ansible https://github.com/contiv/ansible HEAD --squash
+
 reflex:
 	@echo 'To use this task, `go get github.com/cespare/reflex`'
 
@@ -170,8 +173,10 @@ tar: clean-tar
 clean-tar:
 	@rm -f $(TAR_LOC)/*.$(TAR_EXT)
 
+release:
+
 # GITHUB_USER and GITHUB_TOKEN are needed be set to run github-release
-release: tar
+release-github: tar
 	@go get github.com/aktau/github-release
 	@latest_tag=$$(git describe --tags `git rev-list --tags --max-count=1`); \
 		comparison="$$latest_tag..HEAD"; \
@@ -182,6 +187,3 @@ release: tar
 		( github-release -v upload -r volplugin -t $(VERSION) -n $(TAR_FILENAME) -f $(TAR_FILE) || \
 		github-release -v delete -r volplugin -t $(VERSION) ) ) || exit 1
 	@make clean-tar
-
-vendor-ansible:
-	git subtree pull --prefix ansible https://github.com/contiv/ansible HEAD --squash


### PR DESCRIPTION
The release builds, while nice when we were pre-versioned are broken; they still tag at v0.0.0. Additionally, they add a lot of noise to the releases page which drown the actual point releases' notes.

I think soon our release tooling will need to be revisited, but this is a first step.