### PR TITLE
README.md,config,systemtests,volplugin: remove IOPS controls.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ release.
 * Manage many kinds of filesystems, including providing mkfs commands.
 * Snapshot frequency and pruning. Also copy snapshots to new volumes!
 * Ephemeral (removed on container teardown) volumes
-* IOPS limiting (via blkio cgroup)
+* BPS limiting (via blkio cgroup)
 
 volplugin is still alpha at the time of this writing; features and the API may
 be extremely volatile and it is not suggested that you use this in production.

--- a/config/volume.go
+++ b/config/volume.go
@@ -48,10 +48,8 @@ type RuntimeOptions struct {
 
 // RateLimitConfig is the configuration for limiting the rate of disk access.
 type RateLimitConfig struct {
-	WriteIOPS uint   `json:"write-iops" merge:"rate-limit.write.iops"`
-	ReadIOPS  uint   `json:"read-iops" merge:"rate-limit.read.iops"`
-	WriteBPS  uint64 `json:"write-bps" merge:"rate-limit.write.bps"`
-	ReadBPS   uint64 `json:"read-bps" merge:"rate-limit.read.bps"`
+	WriteBPS uint64 `json:"write-bps" merge:"rate-limit.write.bps"`
+	ReadBPS  uint64 `json:"read-bps" merge:"rate-limit.read.bps"`
 }
 
 // SnapshotConfig is the configuration for snapshots.

--- a/config/volume_test.go
+++ b/config/volume_test.go
@@ -203,18 +203,18 @@ func (s *configSuite) TestVolumeRuntime(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(s.tlc.PublishVolume(vol), IsNil)
 	runtime := vol.RuntimeOptions
-	runtime.RateLimit.ReadIOPS = 1000
+	runtime.RateLimit.ReadBPS = 1000
 	c.Assert(s.tlc.PublishVolumeRuntime(vol, runtime), IsNil)
 
 	runtime2, err := s.tlc.GetVolumeRuntime("policy1", "test")
 	c.Assert(err, IsNil)
-	c.Assert(runtime2.RateLimit.ReadIOPS, Equals, uint(1000))
+	c.Assert(runtime2.RateLimit.ReadBPS, Equals, uint64(1000))
 	c.Assert(runtime, DeepEquals, runtime2)
 
 	vol, err = s.tlc.GetVolume("policy1", "test")
 	c.Assert(err, IsNil)
 	c.Assert(vol.RuntimeOptions, DeepEquals, runtime2)
-	c.Assert(vol.RuntimeOptions.RateLimit.ReadIOPS, Equals, uint(1000))
+	c.Assert(vol.RuntimeOptions.RateLimit.ReadBPS, Equals, uint64(1000))
 }
 
 func (s *configSuite) TestToDriverOptions(c *C) {

--- a/systemtests/init_test.go
+++ b/systemtests/init_test.go
@@ -44,18 +44,6 @@ func (s *systemtestSuite) SetUpSuite(c *C) {
 	stopServices := []string{"volplugin", "apiserver", "volsupervisor"}
 	startServices := []string{"ceph.target", "etcd"}
 
-	/* FIXME too volatile. The intent was to ensure ceph was not a factor in some
-	   of our work. I'm not sure this is as necessary now, but we should do it if
-	   we have the time to do it properly. We'll need better orchestration here.
-
-		if cephDriver() {
-			startServices = append(startServices, "ceph.target")
-		} else {
-			stopServices = append(stopServices, "ceph.target")
-		}
-
-	*/
-
 	nodelen := len(s.vagrant.GetNodes())
 	sync := make(chan struct{}, nodelen)
 

--- a/systemtests/integrated_test.go
+++ b/systemtests/integrated_test.go
@@ -115,24 +115,18 @@ func (s *systemtestSuite) TestIntegratedRateLimiting(c *C) {
 
 	// FIXME find a better place for these
 	var (
-		writeIOPSFile = "/sys/fs/cgroup/blkio/blkio.throttle.write_iops_device"
-		readIOPSFile  = "/sys/fs/cgroup/blkio/blkio.throttle.read_iops_device"
-		writeBPSFile  = "/sys/fs/cgroup/blkio/blkio.throttle.write_bps_device"
-		readBPSFile   = "/sys/fs/cgroup/blkio/blkio.throttle.read_bps_device"
+		writeBPSFile = "/sys/fs/cgroup/blkio/blkio.throttle.write_bps_device"
+		readBPSFile  = "/sys/fs/cgroup/blkio/blkio.throttle.read_bps_device"
 	)
 
 	opts := map[string]string{
-		"rate-limit.write.bps":  "100000",
-		"rate-limit.write.iops": "110000",
-		"rate-limit.read.bps":   "120000",
-		"rate-limit.read.iops":  "130000",
+		"rate-limit.write.bps": "100000",
+		"rate-limit.read.bps":  "120000",
 	}
 
 	optMap := map[string]string{
-		"rate-limit.write.bps":  writeBPSFile,
-		"rate-limit.write.iops": writeIOPSFile,
-		"rate-limit.read.bps":   readBPSFile,
-		"rate-limit.read.iops":  readIOPSFile,
+		"rate-limit.write.bps": writeBPSFile,
+		"rate-limit.read.bps":  readBPSFile,
 	}
 
 	volName := fqVolume("policy1", genRandomVolume())
@@ -158,16 +152,14 @@ func (s *systemtestSuite) TestIntegratedRateLimiting(c *C) {
 			}
 		}
 
-		c.Assert(found, Equals, true)
+		c.Assert(found, Equals, true, Commentf(out))
 	}
 
 	s.volcli(fmt.Sprintf("volume runtime upload %s < /testdata/iops1.json", volName))
 	// copied from iops1.json
 	opts = map[string]string{
-		"rate-limit.write.bps":  "1000000",
-		"rate-limit.write.iops": "1000",
-		"rate-limit.read.bps":   "10",
-		"rate-limit.read.iops":  "1200",
+		"rate-limit.write.bps": "1000",
+		"rate-limit.read.bps":  "10",
 	}
 
 	time.Sleep(30 * time.Second) // TTL

--- a/systemtests/testdata/iops1.json
+++ b/systemtests/testdata/iops1.json
@@ -1,8 +1,6 @@
 {
   "rate-limit": {
-    "write-bps": 1000000,
-    "write-iops": 1000,
-    "read-bps": 10,
-    "read-iops": 1200
+    "write-bps": 1000,
+    "read-bps": 10
   }
 }

--- a/systemtests/util_test.go
+++ b/systemtests/util_test.go
@@ -355,8 +355,10 @@ func waitForAPIServer(node vagrantssh.TestbedNode) error {
 	err := runCommandUntilNoError(node, "pgrep -c apiserver", 10)
 	if err == nil {
 		log.Infof("APIServer is running on %q", node.GetName())
-
 	}
+
+	time.Sleep(time.Second)
+
 	return nil
 }
 

--- a/systemtests/volplugin_test.go
+++ b/systemtests/volplugin_test.go
@@ -106,10 +106,10 @@ func (s *systemtestSuite) TestVolpluginCrashRestart(c *C) {
 	c.Assert(startVolplugin(s.vagrant.GetNode("mon0")), IsNil)
 	c.Assert(waitForVolplugin(s.vagrant.GetNode("mon0")), IsNil)
 
-	_, err = s.volcli(fmt.Sprintf("volume runtime upload %s < /testdata/iops1.json", volName))
-	c.Assert(err, IsNil)
+	out, err := s.volcli(fmt.Sprintf("volume runtime upload %s < /testdata/iops1.json", volName))
+	c.Assert(err, IsNil, Commentf(out))
 	time.Sleep(45 * time.Second)
-	out, err := s.vagrant.GetNode("mon0").RunCommandWithOutput("sudo cat /sys/fs/cgroup/blkio/blkio.throttle.write_iops_device")
+	out, err = s.vagrant.GetNode("mon0").RunCommandWithOutput("sudo cat /sys/fs/cgroup/blkio/blkio.throttle.write_bps_device")
 	c.Assert(err, IsNil)
 	c.Assert(strings.TrimSpace(out), Not(Equals), "")
 	lines := strings.Split(strings.TrimSpace(out), "\n")

--- a/volplugin/cgroup.go
+++ b/volplugin/cgroup.go
@@ -10,10 +10,8 @@ import (
 
 // FIXME find a better place for these
 const (
-	writeIOPSFile = "/sys/fs/cgroup/blkio/blkio.throttle.write_iops_device"
-	readIOPSFile  = "/sys/fs/cgroup/blkio/blkio.throttle.read_iops_device"
-	writeBPSFile  = "/sys/fs/cgroup/blkio/blkio.throttle.write_bps_device"
-	readBPSFile   = "/sys/fs/cgroup/blkio/blkio.throttle.read_bps_device"
+	writeBPSFile = "/sys/fs/cgroup/blkio/blkio.throttle.write_bps_device"
+	readBPSFile  = "/sys/fs/cgroup/blkio/blkio.throttle.read_bps_device"
 )
 
 func makeLimit(mc *storage.Mount, limit uint64) []byte {
@@ -22,10 +20,8 @@ func makeLimit(mc *storage.Mount, limit uint64) []byte {
 
 func applyCGroupRateLimit(ro config.RuntimeOptions, mc *storage.Mount) error {
 	opMap := map[string]uint64{
-		writeIOPSFile: uint64(ro.RateLimit.WriteIOPS),
-		readIOPSFile:  uint64(ro.RateLimit.ReadIOPS),
-		writeBPSFile:  ro.RateLimit.WriteBPS,
-		readBPSFile:   ro.RateLimit.ReadBPS,
+		writeBPSFile: ro.RateLimit.WriteBPS,
+		readBPSFile:  ro.RateLimit.ReadBPS,
 	}
 
 	for fn, val := range opMap {


### PR DESCRIPTION
This removes IOPS controls; we could not guarantee these values for either Ceph or NFS. The BPS rate limiting for Ceph is still applied, and as soon as I can figure out what I need to do with `tc` to handle the NFS side, I will.

Opinions on the change are encouraged. /cc @mapuri @jainvipin 