### PR TITLE
Makefile: add --provision flag to 'reload' target to ensure services are started after VM reboot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ update:
 restart: stop update start
 
 reload:
-	vagrant reload
+	vagrant reload --provision
 
 provision:
 	vagrant provision


### PR DESCRIPTION
This flag should have been added in #346.

See:  https://github.com/contiv/volplugin/issues/332#issuecomment-233085163

Thanks, @mapuri!