### PR TITLE
storage/cgroup,volplugin: new package for manipulating cgroups.

### DIFF
--- a/storage/cgroup/cgroup.go
+++ b/storage/cgroup/cgroup.go
@@ -1,4 +1,4 @@
-package volplugin
+package cgroup
 
 import (
 	"fmt"
@@ -8,7 +8,6 @@ import (
 	"github.com/contiv/volplugin/storage"
 )
 
-// FIXME find a better place for these
 const (
 	writeBPSFile = "/sys/fs/cgroup/blkio/blkio.throttle.write_bps_device"
 	readBPSFile  = "/sys/fs/cgroup/blkio/blkio.throttle.read_bps_device"
@@ -18,7 +17,9 @@ func makeLimit(mc *storage.Mount, limit uint64) []byte {
 	return []byte(fmt.Sprintf("%d:%d %d\n", mc.DevMajor, mc.DevMinor, limit))
 }
 
-func applyCGroupRateLimit(ro config.RuntimeOptions, mc *storage.Mount) error {
+// ApplyCGroupRateLimit applies cgroups based on the runtime options. Current
+// this is restricted to BPS-related functions.
+func ApplyCGroupRateLimit(ro config.RuntimeOptions, mc *storage.Mount) error {
 	opMap := map[string]uint64{
 		writeBPSFile: ro.RateLimit.WriteBPS,
 		readBPSFile:  ro.RateLimit.ReadBPS,

--- a/storage/cgroup/cgroup_test.go
+++ b/storage/cgroup/cgroup_test.go
@@ -1,0 +1,45 @@
+package cgroup
+
+import (
+	"bytes"
+	"io/ioutil"
+	. "testing"
+
+	"github.com/contiv/volplugin/config"
+	"github.com/contiv/volplugin/storage"
+
+	. "gopkg.in/check.v1"
+)
+
+type cgroupSuite struct{}
+
+var _ = Suite(&cgroupSuite{})
+
+func TestCGroup(t *T) { TestingT(t) }
+
+func (s *cgroupSuite) TestApplyCGroupRateLimit(c *C) {
+	err := ApplyCGroupRateLimit(config.RuntimeOptions{
+		RateLimit: config.RateLimitConfig{
+			WriteBPS: 123456,
+			ReadBPS:  654321,
+		},
+	}, &storage.Mount{DevMajor: 253, DevMinor: 0})
+	c.Assert(err, IsNil)
+
+	defer func() {
+		ApplyCGroupRateLimit(config.RuntimeOptions{
+			RateLimit: config.RateLimitConfig{
+				WriteBPS: 0,
+				ReadBPS:  0,
+			},
+		}, &storage.Mount{DevMajor: 253, DevMinor: 0})
+	}()
+
+	content, err := ioutil.ReadFile(writeBPSFile)
+	c.Assert(err, IsNil)
+	c.Assert(string(bytes.TrimSpace(content)), Matches, `^253:0 123456`)
+
+	content, err = ioutil.ReadFile(readBPSFile)
+	c.Assert(err, IsNil)
+	c.Assert(string(bytes.TrimSpace(content)), Matches, `^253:0 654321`)
+}

--- a/volplugin/handlers.go
+++ b/volplugin/handlers.go
@@ -16,6 +16,7 @@ import (
 	"github.com/contiv/volplugin/lock"
 	"github.com/contiv/volplugin/storage"
 	"github.com/contiv/volplugin/storage/backend"
+	"github.com/contiv/volplugin/storage/cgroup"
 )
 
 func (dc *DaemonConfig) get(w http.ResponseWriter, r *http.Request) {
@@ -235,7 +236,7 @@ func (dc *DaemonConfig) mount(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := applyCGroupRateLimit(volConfig.RuntimeOptions, mc); err != nil {
+	if err := cgroup.ApplyCGroupRateLimit(volConfig.RuntimeOptions, mc); err != nil {
 		if dc.mountCounter.Sub(volName) == 0 {
 			if err := driver.Unmount(driverOpts); err != nil {
 				log.Errorf("Could not unmount device for volume %q: %v", volName, err)

--- a/volplugin/runtime.go
+++ b/volplugin/runtime.go
@@ -4,6 +4,7 @@ import (
 	"github.com/contiv/errored"
 	"github.com/contiv/volplugin/config"
 	"github.com/contiv/volplugin/errors"
+	"github.com/contiv/volplugin/storage/cgroup"
 	"github.com/contiv/volplugin/watch"
 
 	log "github.com/Sirupsen/logrus"
@@ -40,7 +41,7 @@ func (dc *DaemonConfig) pollRuntime() {
 			continue
 		}
 
-		if err := applyCGroupRateLimit(vol.RuntimeOptions, thisMC); err != nil {
+		if err := cgroup.ApplyCGroupRateLimit(vol.RuntimeOptions, thisMC); err != nil {
 			log.Error(errored.Errorf("Error processing runtime update for volume %q", vol).Combine(err))
 			continue
 		}


### PR DESCRIPTION
This moves the cgroup manipulation code into `storage/cgroup`, where it belongs.