### PR TITLE
build/scripts: fix systemtest logic

### DIFF
--- a/build/scripts/systemtests.sh
+++ b/build/scripts/systemtests.sh
@@ -7,13 +7,5 @@ then
   export USE_DRIVER=ceph
 fi
 
-#set GOPATH in CI environment
-if [ "x${WORKSPACE}" != "x" ]; then
-    export GOPATH=${WORKSPACE}
-fi
-
-for i in ceph nfs
-do
-  echo running ${USE_DRIVER}-driver tests...
-  go test -v -timeout 240m ./systemtests -check.v -check.f "${TESTRUN}"
-done
+echo running ${USE_DRIVER}-driver tests...
+go test -v -timeout 240m ./systemtests -check.v -check.f "${TESTRUN}"


### PR DESCRIPTION
- remove the loop otherwise the tests run twice adding to test time
- also remove setting GOPATH for the CI environment in scripts, it is better to control it from higher level jenkins job or make target

I found some of these while trying out parallel tests.

/cc @erikh 