### PR TITLE
Makefile: clean up global state associated with the vagrant setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ stop:
 	make clean
 
 clean:
+	([ -n "$$(cat subnet_assignment.state)" ] && rm -rf /tmp/volplugin_vagrant_subnets/`cat subnet_assignment.state`) || :
 	rm -f subnet_assignment.state
 	rm -f *.vdi
 	rm -f .vagrant/*.vmdk


### PR DESCRIPTION
This will help cleanup state on CI machines, once the job has completed. It will be useful otherwise too I think.

/cc @dseevr @erikh 