### PR TITLE
apiserver,config,errors,volcli: add volcli commands to get, list, and watch policy revision changes

### DIFF
--- a/config/archive.go
+++ b/config/archive.go
@@ -1,0 +1,89 @@
+package config
+
+import (
+	"fmt"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/contiv/volplugin/errors"
+	"github.com/contiv/volplugin/watch"
+	"github.com/coreos/etcd/client"
+	"golang.org/x/net/context"
+)
+
+func (c *Client) policyArchive(name string) string {
+	return c.prefixed(rootPolicyArchive, name)
+}
+
+func (c *Client) policyArchiveEntry(name string, timestamp string) string {
+	return c.prefixed(rootPolicyArchive, name, timestamp)
+}
+
+// CreatePolicyRevision creates an revision entry in a policy's history.
+func (c *Client) CreatePolicyRevision(name string, policy string) error {
+	timestamp := fmt.Sprint(time.Now().Unix())
+	key := c.policyArchiveEntry(name, timestamp)
+
+	_, err := c.etcdClient.Set(context.Background(), key, policy, nil)
+	if err != nil {
+		return errors.EtcdToErrored(err)
+	}
+
+	return nil
+}
+
+// ListPolicyRevisions returns a list of all the revisions for a given policy.
+func (c *Client) ListPolicyRevisions(name string) ([]string, error) {
+	keyspace := c.policyArchive(name)
+
+	resp, err := c.etcdClient.Get(context.Background(), keyspace, &client.GetOptions{Sort: true, Recursive: false, Quorum: true})
+	if err != nil {
+		return nil, errors.EtcdToErrored(err)
+	}
+
+	ret := []string{}
+
+	for _, node := range resp.Node.Nodes {
+		_, revision := path.Split(node.Key)
+
+		ret = append(ret, revision)
+	}
+
+	return ret, nil
+}
+
+// GetPolicyRevision returns a single revision for a given policy.
+func (c *Client) GetPolicyRevision(name, revision string) (string, error) {
+	keyspace := c.policyArchiveEntry(name, revision)
+
+	resp, err := c.etcdClient.Get(context.Background(), keyspace, &client.GetOptions{Sort: false, Recursive: false, Quorum: true})
+	if err != nil {
+		return "", errors.EtcdToErrored(err)
+	}
+
+	return resp.Node.Value, nil
+}
+
+// WatchForPolicyChanges creates a watch which returns the policy name and revision
+// whenever a new policy is uploaded.
+func (c *Client) WatchForPolicyChanges(activity chan *watch.Watch) {
+	keyspace := c.prefixed(rootPolicyArchive)
+
+	w := watch.NewWatcher(activity, keyspace, func(resp *client.Response, w *watch.Watcher) {
+		// skip anything not happening _below_ our watch.
+		// we don't care about updates happening to the root of our watch here.
+		if !strings.HasPrefix(resp.Node.Key, keyspace+"/") {
+			return
+		}
+
+		s := strings.TrimPrefix(resp.Node.Key, keyspace+"/")
+
+		name, revision := path.Split(s)
+		name = name[:len(name)-1] // remove trailing slash
+
+		w.Channel <- &watch.Watch{Key: resp.Node.Key, Config: []string{name, revision}}
+	})
+
+	watch.Create(w)
+}

--- a/config/archive_test.go
+++ b/config/archive_test.go
@@ -1,0 +1,70 @@
+package config
+
+import (
+	"github.com/contiv/volplugin/watch"
+	. "gopkg.in/check.v1"
+)
+
+const (
+	testPolicyName = "foobar"
+)
+
+func revisionCount(s *configSuite, c *C) int {
+	revisions, err := s.tlc.ListPolicyRevisions(testPolicyName)
+	if err != nil {
+		// this is a "does not exist" because the policy hasn't been uploaded yet
+		return 0
+	}
+
+	return len(revisions)
+}
+
+func createTestPolicy(s *configSuite, c *C) {
+	err := s.tlc.CreatePolicyRevision(testPolicyName, "{}")
+	c.Assert(err, IsNil)
+}
+
+func (s *configSuite) TestCreatePolicyRevision(c *C) {
+	c.Assert(revisionCount(s, c), Equals, 0)
+	createTestPolicy(s, c)
+	c.Assert(revisionCount(s, c), Equals, 1)
+}
+
+// the logic for testing Get and List only differs in that testing Get verifies
+// that the policy text is what was uploaded, so the two tests are combined here.
+func (s *configSuite) TestGetAndListPolicyRevisions(c *C) {
+	policyText := `{"foo":"bar"}`
+
+	c.Assert(revisionCount(s, c), Equals, 0)
+
+	err := s.tlc.CreatePolicyRevision(testPolicyName, policyText)
+	c.Assert(err, IsNil)
+
+	revisions, err := s.tlc.ListPolicyRevisions(testPolicyName)
+	c.Assert(err, IsNil)
+	c.Assert(len(revisions), Equals, 1)
+
+	resp, err := s.tlc.GetPolicyRevision(testPolicyName, revisions[0])
+	c.Assert(err, IsNil)
+	c.Assert(resp, Equals, policyText)
+}
+
+func (s *configSuite) TestWatchForPolicyChanges(c *C) {
+	activity := make(chan *watch.Watch)
+	s.tlc.WatchForPolicyChanges(activity)
+
+	createTestPolicy(s, c)
+
+	w := <-activity
+
+	watch.Stop(s.tlc.prefixed(rootPolicyArchive))
+
+	changeset := w.Config.([]string)
+	c.Assert(len(changeset), Equals, 2)
+
+	name := changeset[0]
+	revision := changeset[1]
+
+	_, err := s.tlc.GetPolicyRevision(name, revision)
+	c.Assert(err, IsNil)
+}

--- a/config/config.go
+++ b/config/config.go
@@ -18,13 +18,14 @@ import (
 )
 
 const (
-	rootVolume    = "volumes"
-	rootUse       = "users"
-	rootPolicy    = "policies"
-	rootSnapshots = "snapshots"
+	rootVolume        = "volumes"
+	rootUse           = "users"
+	rootPolicy        = "policies"
+	rootPolicyArchive = "policy-archives"
+	rootSnapshots     = "snapshots"
 )
 
-var defaultPaths = []string{rootVolume, rootUse, rootPolicy, rootSnapshots}
+var defaultPaths = []string{rootVolume, rootUse, rootPolicy, rootPolicyArchive, rootSnapshots}
 
 // Request provides a request structure for communicating with the
 // apiserver.

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -106,6 +106,10 @@ var (
 	ListPolicy = errored.New("Listing policies")
 	// PublishPolicy is used when publishing policies.
 	PublishPolicy = errored.New("Publishing policies")
+	// ListPolicyRevision is used when listing policy revisions.
+	ListPolicyRevision = errored.New("Listing policy revisions")
+	// ListPolicyRevision is used when getting a single policy revision.
+	GetPolicyRevision = errored.New("Getting policy revision")
 
 	// RemoveImage is used when removing the underlying ceph RBD image.
 	RemoveImage = errored.New("Removing image")

--- a/volcli/commands.go
+++ b/volcli/commands.go
@@ -76,6 +76,34 @@ var Commands = []cli.Command{
 				Usage:       "List all policies",
 				Action:      PolicyList,
 			},
+			{
+				Name:        "history",
+				Description: "See historical policy revisions",
+				Usage:       "See historical policy revisions",
+				Subcommands: []cli.Command{
+					{
+						Name:        "get",
+						ArgsUsage:   "[policy name] [revision]",
+						Description: "Retrieve a single revision of a policy",
+						Usage:       "Retrieve a single revision of a policy",
+						Action:      PolicyGetRevision,
+					},
+					{
+						Name:        "list",
+						ArgsUsage:   "[policy name]",
+						Description: "List all revisions of a policy",
+						Usage:       "List all revisions of a policy",
+						Action:      PolicyListRevisions,
+					},
+				},
+			},
+			{
+				Name:        "watch",
+				ArgsUsage:   "",
+				Description: "Watch for policy changes",
+				Usage:       "Watch for policy changes",
+				Action:      PolicyWatch,
+			},
 		},
 	},
 	{

--- a/volcli/volcli_test.go
+++ b/volcli/volcli_test.go
@@ -42,6 +42,21 @@ func (s *volcliSuite) TestErrorReturns(c *C) {
 			args: []string{"foo"},
 			err:  errorInvalidArgCount(1, 0, []string{"foo"}),
 		},
+		"policyHistoryGet": {
+			f:    policyGetRevision,
+			args: []string{},
+			err:  errorInvalidArgCount(0, 2, []string{}),
+		},
+		"policyHistoryList": {
+			f:    policyListRevisions,
+			args: []string{},
+			err:  errorInvalidArgCount(0, 1, []string{}),
+		},
+		"policyWatch": {
+			f:    policyWatch,
+			args: []string{"foo"},
+			err:  errorInvalidArgCount(1, 0, []string{"foo"}),
+		},
 		"volumeCreate": {
 			f:    volumeCreate,
 			args: []string{},


### PR DESCRIPTION
- Get all revision numbers: `volcli policy history list $name`
- Retrieve the policy text for a specific revision: `volcli policy history get $name $revision`
- Watch for new policies being uploaded: `volcli policy watch`

Fixes #269