### PR TITLE
Godeps: bump remotessh to the latest known commit

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -30,7 +30,7 @@
 		},
 		{
 			"ImportPath": "github.com/contiv/remotessh",
-			"Rev": "d382e9cea099cb31728d00160b34e52cb9127f28"
+			"Rev": "873176beee0ae1cdcd5ecefb7009d979419138af"
 		},
 		{
 			"ImportPath": "github.com/coreos/etcd/Godeps/_workspace/src/github.com/ugorji/go/codec",

--- a/vendor/github.com/contiv/remotessh/vagrant.go
+++ b/vendor/github.com/contiv/remotessh/vagrant.go
@@ -97,6 +97,7 @@ func (v *Vagrant) setup(start bool, env []string, numNodes int) error {
 	v.nodes = map[string]TestbedNode{}
 
 	vCmd := &VagrantCommand{ContivNodes: numNodes}
+	vCmd.Env = append(vCmd.Env, env...)
 
 	if start {
 		output, err := vCmd.RunWithOutput("up")
@@ -211,13 +212,13 @@ func (v *Vagrant) setup(start bool, env []string, numNodes int) error {
 // Setup initializes a vagrant testbed.
 func (v *Vagrant) Setup(args ...interface{}) error {
 	if _, ok := args[0].(bool); !ok {
-		return unexpectedSetupArgError("bool, []string, int", args...)
+		return unexpectedSetupArgError("bool, string, int", args...)
 	}
 	if _, ok := args[1].([]string); !ok {
-		return unexpectedSetupArgError("bool, []string, int", args...)
+		return unexpectedSetupArgError("bool, string, int", args...)
 	}
 	if _, ok := args[2].(int); !ok {
-		return unexpectedSetupArgError("bool, []string, int", args...)
+		return unexpectedSetupArgError("bool, string, int", args...)
 	}
 
 	return v.setup(args[0].(bool), args[1].([]string), args[2].(int))

--- a/vendor/github.com/contiv/remotessh/vagrantcommand.go
+++ b/vendor/github.com/contiv/remotessh/vagrantcommand.go
@@ -15,15 +15,23 @@ limitations under the License.
 
 package remotessh
 
-import "os/exec"
+import (
+	"os"
+	"os/exec"
+)
 
 // VagrantCommand is a command that is run on a vagrant node
 type VagrantCommand struct {
 	ContivNodes int
+	Env         []string
 }
 
 func (c *VagrantCommand) getCmd(cmd string, args ...string) *exec.Cmd {
-	return exec.Command("vagrant", append([]string{cmd}, args...)...)
+	newArgs := append([]string{cmd}, args...)
+	osCmd := exec.Command("vagrant", newArgs...)
+	osCmd.Env = os.Environ()
+	osCmd.Env = append(osCmd.Env, c.Env...)
+	return osCmd
 }
 
 // Run runs a command and return its exit status


### PR DESCRIPTION
This PR vendors a known version of remotessh. This is the current version of this dependency. I'll bring in some changes to avoid this in the future.