### PR TITLE
Vagrantfile: disable GRO on VirtualBox

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -278,6 +278,14 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         vb.customize ['modifyvm', :id, '--memory', "#{MEMORY}"]
         vb.customize ['modifyvm', :id, '--paravirtprovider', "kvm"]
 
+        override.vm.provision 'shell' do |s|
+          s.inline = <<-EOF
+          ethtool -K enp0s3 gro off
+          ethtool -K enp0s8 gro off
+          EOF
+          s.args = []
+        end
+
         override.vm.provision "shell" do |s|
           s.inline = shell_provision
           s.args = [ ENV["http_proxy"] || "", ENV["https_proxy"] || "" ]


### PR DESCRIPTION
This PR works around some of the VMM bugs discovered in VirtualBox 5.0.x and fixed in 5.1.x. 