### PR TITLE
api: fix the log message for creating a volume: the new String() was …

### DIFF
--- a/api/handlers.go
+++ b/api/handlers.go
@@ -28,7 +28,7 @@ func (a *API) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	log.Infof("Creating volume %s/%s", volume)
+	log.Infof("Creating volume %s", volume)
 
 	hostname, err := os.Hostname()
 	if err != nil {

--- a/config/validation.go
+++ b/config/validation.go
@@ -2,8 +2,9 @@ package config
 
 import (
 	"fmt"
-	"github.com/contiv/errored"
 	"strings"
+
+	"github.com/contiv/errored"
 
 	log "github.com/Sirupsen/logrus"
 
@@ -30,7 +31,6 @@ func (cfg *RuntimeOptions) ValidateJSON() error {
 		return combineErrors(result.Errors())
 	}
 
-	log.Infof("Runtime config validation passed")
 	return nil
 }
 
@@ -49,7 +49,6 @@ func (cfg *Policy) ValidateJSON() error {
 		return err
 	}
 
-	log.Infof("Policy validation passed")
 	return nil
 }
 


### PR DESCRIPTION
…causing it to accept an invalid argument.

Signed-off-by: Erik Hollensbe <github@hollensbe.org>