### PR TITLE
Makefile,build/scripts: validate deps from vendor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,9 @@ ssh:
 checks:
 	vagrant ssh mon0 -c "sudo -i sh -c 'cd $(GUESTGOPATH); ./build/scripts/checks.sh'"
 
+vendor-check:
+	vagrant ssh mon0 -c "sudo -i sh -c 'cd $(GUESTGOPATH); ./build/scripts/validate-godep.sh'"
+
 check-ansible:
 	@build/scripts/check-ansible.sh
 

--- a/build/scripts/validate-godep.sh
+++ b/build/scripts/validate-godep.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+set -x
+
+cd /tmp/
+TEMP_GOPATH=/tmp/$(mktemp -d tempgopath.XXXXXXXXX)
+mkdir -p $TEMP_GOPATH/src/github.com/contiv/volplugin
+tar -c --exclude "*.vdi" --exclude subnet_assignment.state $GOPATH/src/github.com/contiv/volplugin | tar -x --strip-components=5 -C $TEMP_GOPATH/src/github.com/contiv/
+export GOPATH=$TEMP_GOPATH
+cd $GOPATH/src/github.com/contiv/volplugin
+go get github.com/tools/godep
+$GOPATH/bin/godep restore -v
+rm -rf $TEMP_GOPATH
+echo "vendored deps were restored"


### PR DESCRIPTION
Godep makes it possible to vendor a locally modified dependency. This isn't a major issue when it comes to the properly functioning code which depends on it. This is a major issues when trying to restore the deps using `godep restore` and when trying to bump a dependency.

This PR adds a script which makes it possible to check that `godep restore` doesn't rely on any locally modified deps. This lets us avoid the issue of having a local commit hash added to Godeps.json and the files of that particular commit added to vendor.