### PR TITLE
fix docker version for volplugin-* container build

### DIFF
--- a/Dockerfile.autorun
+++ b/Dockerfile.autorun
@@ -1,4 +1,4 @@
-FROM docker
+FROM docker:1.11.2
 
 ADD systemtests/testdata/ceph/policy1.json /policy.json
 ADD systemtests/testdata/globals/global1.json /global.json


### PR DESCRIPTION
Since `Dockerfile.autorun` always pulls the latest docker version, we get into API incompatibility issues. So, fixing the docker version in the Dockerfile. 

```
Aug 04 06:43:28 mon0 volplugin.sh[25990]: + docker run --net host --name volplugin --privileged -i -d -v /dev:/dev -v /lib/modules:/lib/modules:ro -v /var/run/docker...
Aug 04 06:43:28 mon0 volplugin.sh[25990]: docker: Error response from daemon: client is newer than server (client API version: 1.24, server API version: 1.23).
Aug 04 06:43:28 mon0 volplugin.sh[25990]: See 'docker run --help'.
```