### PR TITLE
build: restart stopped containers instead of new ones

### DIFF
--- a/build/scripts/apiserver.sh
+++ b/build/scripts/apiserver.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-usage="$0 start|stop"
+usage="$0 start|stop|rm"
 if [ $# -ne 1  ]; then
     echo USAGE: $usage
     exit 1
@@ -20,6 +20,12 @@ start)
 
 stop)
     echo stopping apiserver
+    rm -f /tmp/apiserver-fifo
+    docker stop apiserver
+    ;;
+
+rm)
+    echo removing apiserver container
     rm -f /tmp/apiserver-fifo
     docker stop apiserver
     docker rm -v apiserver

--- a/build/scripts/contiv-vol-run.sh
+++ b/build/scripts/contiv-vol-run.sh
@@ -2,8 +2,25 @@
 
 set -e
 
-# cleanup the older container
-docker rm -f "$1" &>/dev/null || :
+# Check if the container already exists
+if docker inspect -f {{.State.Running}} $1 &>/dev/null
+then
+    # if the container is already running -> return
+    if docker inspect -f {{.State.Running}} $1 | grep "true" &>/dev/null
+    then
+        echo $1 "container is already running"
+        exit 0
+    fi
+
+    # if the container is in stopped state -> `docker start` it
+    if docker inspect -f {{.State.Running}} $1 | grep "false" &>/dev/null
+    then
+        echo $1 "container exists. Restarting it."
+        docker start $1
+        exit 0
+    fi
+fi
+
 
 ## test for shared mount capability
 if ! grep "MountFlags" /lib/systemd/system/docker.service | grep shared &>/dev/null

--- a/build/scripts/volplugin.sh
+++ b/build/scripts/volplugin.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-usage="$0 start|stop"
+usage="$0 start|stop|rm"
 if [ $# -ne 1  ]; then
     echo USAGE: $usage
     exit 1
@@ -20,6 +20,12 @@ start)
 
 stop)
     echo stopping volplugin
+    rm -f /tmp/volplugin-fifo
+    docker stop volplugin
+    ;;
+
+rm)
+    echo removing volplugin container
     rm -f /tmp/volplugin-fifo
     docker stop volplugin
     docker rm -v volplugin

--- a/build/scripts/volsupervisor.sh
+++ b/build/scripts/volsupervisor.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-usage="$0 start|stop"
+usage="$0 start|stop|rm"
 if [ $# -ne 1  ]; then
     echo USAGE: $usage
     exit 1
@@ -21,6 +21,12 @@ start)
 
 stop)
     echo stopping volsupervisor
+    rm -f /tmp/volsupervisor-fifo
+    docker stop volsupervisor
+    ;;
+
+rm)
+    echo removing volsupervisor container
     rm -f /tmp/volsupervisor-fifo
     docker stop volsupervisor
     docker rm -v volsupervisor


### PR DESCRIPTION


`systemctl stop volplugin/volsupervisor/apiserver` now stops the container and does not remove it. when a `systemctl start` is issued, the same container is started again. a `rm` target is also added to `volplugin.sh/volsupervisor.sh/apiserver.sh` which will optionally remove the containers too.

Signed-off-by: Vikrant Balyan <vijayvikrant84@gmail.com>