### PR TITLE
volmigrate, Makefile: add volmigrate tool which can list and run schema migrations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,8 +120,8 @@ run-apiserver:
 
 run-build:
 	GOGC=1000 go install -v \
-		 -ldflags '-X main.version=$(if $(BUILD_VERSION),$(BUILD_VERSION),devbuild)' \
-		 ./volcli/volcli/ ./volplugin/volplugin/ ./apiserver/apiserver/ ./volsupervisor/volsupervisor/
+		-ldflags '-X main.version=$(if $(BUILD_VERSION),$(BUILD_VERSION),devbuild)' \
+		./volcli/volcli/ ./volplugin/volplugin/ ./apiserver/apiserver/ ./volsupervisor/volsupervisor/ ./volmigrate/volmigrate/
 	cp $(GUESTBINPATH)/* bin/
 
 system-test: system-test-ceph system-test-nfs
@@ -163,7 +163,7 @@ TAR_FILE := $(TAR_LOC)/$(TAR_FILENAME)
 
 tar: clean-tar
 	@echo "v0.0.0-`date -u +%m-%d-%Y.%H-%M-%S.UTC`" > $(VERSION_FILE)
-	@tar -jcf $(TAR_FILE) -C ${PWD}/bin volcli apiserver volplugin volsupervisor -C ${PWD} contrib
+	@tar -jcf $(TAR_FILE) -C ${PWD}/bin volcli apiserver volplugin volsupervisor volmigrate -C ${PWD} contrib
 
 clean-tar:
 	@rm -f $(TAR_LOC)/*.$(TAR_EXT)

--- a/volmigrate/backend/backend.go
+++ b/volmigrate/backend/backend.go
@@ -1,0 +1,38 @@
+package backend
+
+const SchemaVersionKey = "schema-version"
+
+// Backend defines the interface for a type which implements the functionality to talk
+// to a given datastore (etcd2, etcd3, consul, etc.)
+type Backend interface {
+	// CurrentSchemaVersion returns the version of the last migration which was successfuly run.
+	// This is used to ensure that the migration we're about to run hasn't been run already.
+	// If the version key does not exist, it will return 0.
+	CurrentSchemaVersion() int64
+
+	// CreateDirectory creates a directory at the target path.
+	// It acts like mkdir -p, e.g., it won't fail if the directory already exists and
+	// can create any depth of nested folder hierarchy.
+	// If the target path exists and is a file, it will return an error.
+	CreateDirectory(path string) error
+
+	// CreateKey will create a key at the target location.
+	// If the target key already exists or is a directory, it will return an error.
+	CreateKey(path string, contents []byte) error
+
+	// DeleteDirectory will recursively delete a target directory.
+	// If the target directory doesn't exist, it's not considered a failure.
+	// If the target directory is a file, it will return an error.
+	DeleteDirectory(path string) error
+
+	// DeleteKey will delete the target key if it exists.
+	// If the target key doesn't exist, it's not considered a failure.
+	// If the target key is a directory, it will refuse to remove it and will return an error.
+	DeleteKey(path string) error
+
+	// Name returns the name of the engine ("etcd2", "etcd3", "consul", etc.)
+	Name() string
+
+	// UpdateSchemaVersion records the version number of the latest migration which successfully ran.
+	UpdateSchemaVersion(version int64) error
+}

--- a/volmigrate/backend/etcd2/etcd2.go
+++ b/volmigrate/backend/etcd2/etcd2.go
@@ -1,0 +1,125 @@
+package etcd2
+
+import (
+	"fmt"
+	"log"
+	"path"
+	"strconv"
+
+	"github.com/contiv/errored"
+	"github.com/contiv/volplugin/errors"
+	"github.com/contiv/volplugin/volmigrate/backend"
+	"github.com/coreos/etcd/client"
+	"golang.org/x/net/context"
+)
+
+func New(prefix string, etcdHosts []string) *Engine {
+	etcdCfg := client.Config{
+		Endpoints: etcdHosts,
+	}
+
+	etcdClient, err := client.New(etcdCfg)
+	if err != nil {
+		log.Fatalf("Failed to create etcd client: %s", err)
+	}
+
+	return &Engine{
+		etcdClient: client.NewKeysAPI(etcdClient),
+		prefix:     prefix,
+	}
+}
+
+// Engine is a migration engine for an etcd v2 datastore.
+type Engine struct {
+	etcdClient client.KeysAPI
+	prefix     string
+}
+
+// CurrentSchemaVersion returns the version of the last migration which was successfuly run.
+// If no previous migrations have been run, the schema version is 0.
+// If there's any error besides "key doesn't exist", execution is aborted.
+func (e *Engine) CurrentSchemaVersion() int64 {
+	resp, err := e.etcdClient.Get(context.Background(), path.Join(e.prefix, backend.SchemaVersionKey), nil)
+	if err != nil {
+		if err := errors.EtcdToErrored(err); err != nil && err == errors.NotExists {
+			return 0 // no key = schema version 0
+		}
+
+		log.Fatalf("Unexpected error when looking up schema version: %v\n", err)
+	}
+
+	i, err := strconv.Atoi(resp.Node.Value)
+	if err != nil {
+		log.Fatalf("Got back unexpected schema version data: %v\n", resp.Node.Value)
+	}
+
+	return int64(i)
+}
+
+// CreateDirectory creates a directory at the target path.
+func (e *Engine) CreateDirectory(target string) error {
+	fmt.Println("Creating directory: " + target)
+	if _, err := e.etcdClient.Set(context.Background(), path.Join(e.prefix, target), "", &client.SetOptions{Dir: true}); err != nil {
+		return errored.Errorf("Failed to create directory: %s", err)
+	}
+
+	return nil
+}
+
+// CreateKey will create a key at the target location.
+func (e *Engine) CreateKey(target string, contents []byte) error {
+	fmt.Println("Creating key: " + target)
+	if _, err := e.etcdClient.Set(context.Background(), path.Join(e.prefix, target), string(contents), nil); err != nil {
+		errored.Errorf("Failed to create key: %s", err)
+	}
+
+	return nil
+}
+
+// DeleteDirectory will recursively delete a target directory.
+func (e *Engine) DeleteDirectory(target string) error {
+	fmt.Println("Deleting directory: " + target)
+
+	if _, err := e.etcdClient.Delete(context.Background(), path.Join(e.prefix, target), &client.DeleteOptions{Dir: true, Recursive: true}); err != nil {
+		return errored.Errorf("Failed to delete directory: %s", err)
+	}
+
+	return nil
+}
+
+// DeleteKey will delete the target key if it exists.
+func (e *Engine) DeleteKey(target string) error {
+	fmt.Println("Deleting key: " + target)
+
+	if _, err := e.etcdClient.Delete(context.Background(), path.Join(e.prefix, target), &client.DeleteOptions{Dir: false}); err != nil {
+		return errored.Errorf("Failed to delete key: %s", err)
+	}
+
+	return nil
+}
+
+// Name returns the name of the engine ("etcd2", "etcd3", "consul", etc.)
+func (e *Engine) Name() string {
+	return "etcd2"
+}
+
+// UpdateSchemaVersion records the version number of the latest migration which successfully ran.
+// If the new version number is <= the current version number, it will log a fatal error.
+func (e *Engine) UpdateSchemaVersion(newVersion int64) error {
+	fmt.Printf("Updating schema version key to: %d\n", newVersion)
+
+	currentVersion := e.CurrentSchemaVersion()
+
+	// sanity check to make sure the version number is actually increasing
+	if newVersion <= currentVersion {
+		log.Fatalf("Cowardly refusing to update schema version to a version <= the current version.  Current: %d, Desired: %d\n", currentVersion, newVersion)
+	}
+
+	data := strconv.Itoa(int(newVersion))
+
+	if _, err := e.etcdClient.Set(context.Background(), path.Join(e.prefix, backend.SchemaVersionKey), data, nil); err != nil {
+		return errored.Errorf("Failed to update schema version key to %d: %s", newVersion, err)
+	}
+
+	return nil
+}

--- a/volmigrate/commands.go
+++ b/volmigrate/commands.go
@@ -1,0 +1,46 @@
+package volmigrate
+
+import "github.com/codegangsta/cli"
+
+// GlobalFlags are required global flags for the operation of volmigrate.
+var GlobalFlags = []cli.Flag{
+	cli.BoolFlag{
+		Name:  "silent",
+		Usage: "disables prompting before running migrations",
+	},
+	cli.StringFlag{
+		Name:  "prefix",
+		Usage: "prefix key used in etcd for namespacing",
+		Value: "/volplugin",
+	},
+	cli.StringSliceFlag{
+		Name:  "etcd",
+		Usage: "URL for etcd",
+		Value: &cli.StringSlice{"http://localhost:2379"},
+	},
+}
+
+// Commands is the data structure which describes the command hierarchy for volmigrate.
+var Commands = []cli.Command{
+	{
+		Name:        "list",
+		ArgsUsage:   "",
+		Usage:       "Lists all schema migration versions",
+		Description: "Produces a newline-delimited list of all available schema migration versions",
+		Action:      ListMigrations,
+	},
+	{
+		Name:        "run",
+		ArgsUsage:   "[version]",
+		Usage:       "Runs schema migrations",
+		Description: "Runs one or all pending schema migrations",
+		Action:      RunMigrations,
+	},
+	{
+		Name:        "version",
+		ArgsUsage:   "",
+		Usage:       "See the current schema version",
+		Description: "See the current schema version",
+		Action:      ShowVersions,
+	},
+}

--- a/volmigrate/migration.go
+++ b/volmigrate/migration.go
@@ -1,0 +1,32 @@
+package volmigrate
+
+import (
+	"fmt"
+
+	"github.com/contiv/errored"
+	"github.com/contiv/volplugin/volmigrate/backend"
+)
+
+// Migration represents a migration that volmigrate can run.
+type Migration struct {
+	Version     int64  // each new migration increments this value, must be >= 1
+	Description string // e.g., "volplugin 1.3 release"
+	runner      func(backend.Backend) error
+}
+
+// Run executes the migration using a supplied backend.Backend
+func (m *Migration) Run(b backend.Backend) error {
+	fmt.Printf("Running migration #%d against %s backend\n", m.Version, b.Name())
+
+	if err := m.runner(b); err != nil {
+		return errored.Errorf("Encountered error during migration %d", m.Version).Combine(err)
+	}
+
+	if err := b.UpdateSchemaVersion(m.Version); err != nil {
+		return errored.Errorf("Successfully applied migration but failed to update schema version key").Combine(err)
+	}
+
+	fmt.Println("")
+
+	return nil
+}

--- a/volmigrate/schema_migrations.go
+++ b/volmigrate/schema_migrations.go
@@ -1,0 +1,64 @@
+package volmigrate
+
+import (
+	"log"
+	"sync"
+
+	"github.com/contiv/volplugin/volmigrate/backend"
+)
+
+var registrationLock sync.Mutex
+var availableMigrations map[int64]*Migration
+var latestMigrationVersion int64
+
+func init() {
+	availableMigrations = make(map[int64]*Migration)
+	registerMigrations()
+}
+
+// registerMigration makes volmigrate aware of a new migration that can be run.
+// If the version number has already been used, it will log a fatal error.
+// If the version number is not the next one in the sequence (incremented by 1), it will log a fatal error.
+func registerMigration(version int64, description string, f func(backend backend.Backend) error) {
+	if version < 1 {
+		log.Fatalf("Migration versions must be > 0, got: %d\n", version)
+	}
+
+	registrationLock.Lock()
+	defer registrationLock.Unlock()
+
+	expectedVersion := latestMigrationVersion + 1
+
+	if version != expectedVersion {
+		log.Fatalf("Expected version '%d', got version '%d'\n", expectedVersion, version)
+	}
+
+	_, found := availableMigrations[version]
+	if found {
+		log.Fatalf("Version '%d' is already in use by another migration\n", version)
+	}
+
+	m := &Migration{
+		Version:     version,
+		Description: description,
+		runner:      f,
+	}
+
+	availableMigrations[version] = m
+	latestMigrationVersion = version
+}
+
+// If a migration returns an error, volmigrate execution is aborted and the schema version key
+// is not updated.  If an operation in a migration can legitimately fail without causing problems,
+// don't check the error value from the Create/Delete call.
+// Paths are relative to /volplugin and don't require a slash at the beginning:
+// e.g., CreateDirectory("foo/bar") will create "/volplugin/foo/bar"
+func registerMigrations() {
+
+	// This migration does nothing, but the backend.SchemaVersionKey key will be
+	// created and populated after it finishes.
+	registerMigration(1, "Create initial schema version key", func(b backend.Backend) error {
+		return nil
+	})
+
+}

--- a/volmigrate/volmigrate.go
+++ b/volmigrate/volmigrate.go
@@ -1,0 +1,169 @@
+package volmigrate
+
+import (
+	"bufio"
+	"fmt"
+	"log"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/codegangsta/cli"
+	"github.com/contiv/errored"
+	"github.com/contiv/volplugin/volmigrate/backend"
+	"github.com/contiv/volplugin/volmigrate/backend/etcd2"
+)
+
+// -------------------------------------------------------------------------------------------------
+
+// NOTE: These three functions are copied from volcli.go
+//       Rather than creating a one-off package for them, they are intentionally directly copied.
+//       If another app like volcli/volmigrate is added in the future, we should extract these
+//       to a separate package.
+
+func errExit(ctx *cli.Context, err error, help bool) {
+	fmt.Fprintf(os.Stderr, "\nError: %v\n\n", err)
+	if help {
+		cli.ShowAppHelp(ctx)
+	}
+	os.Exit(1)
+}
+
+func execCliAndExit(ctx *cli.Context, f func(ctx *cli.Context) (bool, error)) {
+	if showHelp, err := f(ctx); err != nil {
+		errExit(ctx, err, showHelp)
+	}
+}
+
+func errorInvalidArgCount(rcvd, exptd int, args []string) error {
+	return errored.Errorf("Invalid number of arguments: expected %d but received %d %v", exptd, rcvd, args)
+}
+
+// -------------------------------------------------------------------------------------------------
+
+func promptBeforeRunning(ctx *cli.Context, msg string) {
+	if ctx.GlobalBool("silent") {
+		return
+	}
+
+	fmt.Println(msg)
+	fmt.Println("Are you sure you want to continue? y/n")
+
+	reader := bufio.NewReader(os.Stdin)
+	text, err := reader.ReadString('\n')
+	if err != nil {
+		log.Fatalf("Failed to read input from stdin: %s", err)
+	}
+
+	text = strings.ToLower(text)
+	text = text[:len(text)-1] // strip newline
+
+	if text != "yes" && text != "y" {
+		fmt.Println("Aborting.")
+		os.Exit(1)
+	}
+}
+
+// ListMigrations returns a newline-delimited list of migration versions and their descriptions.
+func ListMigrations(ctx *cli.Context) {
+	execCliAndExit(ctx, listMigrations)
+}
+
+func listMigrations(ctx *cli.Context) (bool, error) {
+	if len(ctx.Args()) != 0 {
+		return true, errorInvalidArgCount(len(ctx.Args()), 0, ctx.Args())
+	}
+
+	for i := int64(1); i <= latestMigrationVersion; i++ {
+		m := availableMigrations[i]
+
+		fmt.Printf("%d - %s\n", m.Version, m.Description)
+	}
+
+	return false, nil
+}
+
+// RunMigrations runs either a single pending migration or all pending migrations.
+// If no migrations need to be run, a message will state that nothing was performed.
+func RunMigrations(ctx *cli.Context) {
+	execCliAndExit(ctx, runMigrations)
+}
+
+func runMigrations(ctx *cli.Context) (bool, error) {
+	e := etcd2.New(ctx.GlobalString("prefix"), ctx.GlobalStringSlice("etcd"))
+
+	if len(ctx.Args()) > 0 {
+		i, err := strconv.Atoi(ctx.Args()[0])
+		if err != nil {
+			return true, errored.Errorf("Invalid migration version: %v", ctx.Args()[0])
+		}
+
+		targetVersion := int64(i)
+
+		if targetVersion < 1 || targetVersion > latestMigrationVersion {
+			return false, errored.Errorf("%d is outside valid migration range - min: 1, max %d", targetVersion, latestMigrationVersion)
+		}
+
+		promptBeforeRunning(ctx, fmt.Sprintf("You have requested to run all pending migrations up to and including #%d.", targetVersion))
+		return runMigrationsUpTo(e, targetVersion)
+	}
+
+	promptBeforeRunning(ctx, "You have requested to run all pending migrations.")
+	return runAllMigrations(e)
+}
+
+func runAllMigrations(b backend.Backend) (bool, error) {
+	return runMigrationsUpTo(b, latestMigrationVersion)
+}
+
+func runMigrationsUpTo(b backend.Backend, targetVersion int64) (bool, error) {
+	migrationsRun := 0
+
+	currentVersion := b.CurrentSchemaVersion()
+
+	for i := int64(1); i <= latestMigrationVersion; i++ {
+		m := availableMigrations[i]
+
+		// skip migrations we've already run
+		if currentVersion >= m.Version {
+			continue
+		}
+
+		// run migrations up to and through our target version.
+		if m.Version > targetVersion {
+			break
+		}
+
+		if err := m.Run(b); err != nil {
+			return false, err
+		}
+
+		migrationsRun++
+	}
+
+	if migrationsRun == 0 {
+		fmt.Println("No migrations needed to be run.")
+	} else {
+		fmt.Println("All migrations ran successfully.")
+	}
+
+	return false, nil
+}
+
+// ShowVersions prints the current schema version and the newest version that's available.
+func ShowVersions(ctx *cli.Context) {
+	execCliAndExit(ctx, showVersions)
+}
+
+func showVersions(ctx *cli.Context) (bool, error) {
+	if len(ctx.Args()) != 0 {
+		return true, errorInvalidArgCount(len(ctx.Args()), 0, ctx.Args())
+	}
+
+	e := etcd2.New(ctx.GlobalString("prefix"), ctx.GlobalStringSlice("etcd"))
+
+	fmt.Printf("Current local schema version: %d\n", e.CurrentSchemaVersion())
+	fmt.Printf("Newest available schema version: %d\n", latestMigrationVersion)
+
+	return false, nil
+}

--- a/volmigrate/volmigrate/cli.go
+++ b/volmigrate/volmigrate/cli.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/codegangsta/cli"
+	"github.com/contiv/volplugin/volmigrate"
+)
+
+// version is provided by build
+var version = ""
+
+func main() {
+	app := cli.NewApp()
+
+	app.Version = version
+	app.Flags = volmigrate.GlobalFlags
+	app.Usage = "Run schema migrations"
+	app.ArgsUsage = ""
+	app.Commands = volmigrate.Commands
+
+	if err := app.Run(os.Args); err != nil {
+		fmt.Fprintf(os.Stderr, "\nError: %v\n\n", err)
+		os.Exit(1)
+	}
+}

--- a/volmigrate/volmigrate_test.go
+++ b/volmigrate/volmigrate_test.go
@@ -1,0 +1,18 @@
+package volmigrate
+
+import (
+	. "testing"
+
+	. "gopkg.in/check.v1"
+)
+
+type volmigrateSuite struct {
+}
+
+var _ = Suite(&volmigrateSuite{})
+
+func TestVolmigrate(t *T) { TestingT(t) }
+
+func (s *volmigrateSuite) TestStuff(c *C) {
+	c.Assert(nil, IsNil)
+}


### PR DESCRIPTION
Commands:

`volmigrate list`          -> see all migration versions and descriptions
`volmigrate run [version]` -> run all pending migrations up to [version]
`volmigrate run`           -> run all pending migrations
`volmigrate version`       -> see the local schema version (0 if no migrations have ever run)

The current schema version is held in the "/volplugin/schema-version" key.  Each migration will increment the version by 1 (i.e., the first migration is 1, the second is 2, and so on).  Migration numbers can't be reused.

There is an optional global --silent flag to suppress the confirmation prompt when attempting to run migrations.

Signed-off-by: Bill Robinson <dseevr@users.noreply.github.com>

Fixes #353 