### PR TITLE
Fix dangling ttl goroutine

### DIFF
--- a/systemtests/util_test.go
+++ b/systemtests/util_test.go
@@ -384,7 +384,8 @@ func waitForAPIServer(node remotessh.TestbedNode) error {
 	if err == nil {
 		log.Infof("APIServer is running on %q", node.GetName())
 	}
-	time.Sleep(time.Second)
+
+	time.Sleep(2 * time.Second)
 	return nil
 }
 


### PR DESCRIPTION
This fixes an ordering issue in the locking code where a goroutine would dangle, or be left unchecked, refreshing a TTL on a lock that no longer needed to be held. Additionally, if the mount failed the lock would not be cleared.

I also fixed a small test issue with taking enough time to boot the API server.