### PR TITLE
build,systemtests: wait for apiserver to be reachable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ clean-volplugin-containers:
 	set -e; for i in $$(seq 0 $$(($$(vagrant status | grep -cE 'mon.*running') - 1))); do vagrant ssh mon$$i -c 'docker ps | grep "volplugin" | cut -d " " -f 1 | xargs docker rm -fv'; done
 
 run: build
-	set -e; for i in $$(seq 0 $$(($$(vagrant status | grep -cE 'mon.*running') - 1))); do vagrant ssh mon$$i -c 'cd $(GUESTGOPATH) && ./build/scripts/build-volplugin-containers.sh && make run-volplugin run-apiserver'; done
+	set -e; for i in $$(seq 0 $$(($$(vagrant status | grep -cE 'mon.*running') - 1))); do vagrant ssh mon$$i -c 'cd $(GUESTGOPATH) && ./build/scripts/build-volplugin-containers.sh && ./build/scripts/deps.sh && make run-volplugin run-apiserver'; done
 	vagrant ssh mon0 -c 'cd $(GUESTGOPATH) && make run-volsupervisor'
 	sleep 10
 	vagrant ssh mon0 -c 'volcli global upload < /testdata/globals/global1.json'

--- a/build/scripts/deps.sh
+++ b/build/scripts/deps.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+echo "Fetching connwait..."
+[ -n "`which connwait`" ] || sudo -E $(which go) get github.com/erikh/connwait

--- a/systemtests/util_test.go
+++ b/systemtests/util_test.go
@@ -385,7 +385,13 @@ func waitForAPIServer(node remotessh.TestbedNode) error {
 		log.Infof("APIServer is running on %q", node.GetName())
 	}
 
-	time.Sleep(2 * time.Second)
+	then := time.Now()
+	err = runCommandUntilNoError(node, "connwait 127.0.0.1:9005", 60)
+	if err != nil {
+		return err
+	}
+	log.Infof("Took %s for apiserver on %q to be accessible", time.Since(then), node.GetName())
+
 	return nil
 }
 


### PR DESCRIPTION
We were hitting apiserver before it was ready to serve requests.
This PR uses `connwait` to wait for apiserver to be ready.
we also keep track of time it takes to become accessible.

Signed-off-by: Vikrant Balyan <vijayvikrant84@gmail.com>