### PR TITLE
build: ensure that new code runs in containers on make run

### DIFF
--- a/build/scripts/build-volplugin-containers.sh
+++ b/build/scripts/build-volplugin-containers.sh
@@ -1,4 +1,12 @@
 #!/bin/bash
+
+# In order for the new binaries to take effect we need to clean the older environment
+# Otherwise the binaries stick to older container images
+# repeated docker builds also lead to dangling images, which need to be cleaned too.
+docker ps -a | grep -e volplugin -e apiserver -e volsupervisor | awk '{print $1}' | xargs docker rm -fv
+docker rmi contiv/volplugin
+docker rmi $(docker images -f "dangling=true" -q)
+
 docker build -t contiv/volplugin .
 
 # Ensure that docker is running with MountFlags=shared


### PR DESCRIPTION
When doing a make run, we need to clean up earlier contiv/volplugin docker
image from the system. This also mandates that any containers using the
image are stopped and removed.
Additionally, repeatedly running `docker build` can lead to dangling images.
These are also cleaned.

Signed-off-by: Vikrant Balyan <vijayvikrant84@gmail.com>