### PR TITLE
Return volume at snapshot copy time

### DIFF
--- a/apiserver/daemon.go
+++ b/apiserver/daemon.go
@@ -526,6 +526,18 @@ func (d *DaemonConfig) handleCopy(w http.ResponseWriter, r *http.Request) {
 		)).Combine(err))
 		return
 	}
+
+	content, err := json.Marshal(newVolConfig)
+	if err != nil {
+		api.RESTHTTPError(w, errors.PublishVolume.Combine(errored.Errorf(
+			"Creating new volume %q from volume %q, snapshot %q",
+			req.Options["target"],
+			volConfig.String(),
+			req.Options["snapshot"],
+		)).Combine(err))
+	}
+
+	w.Write(content)
 }
 
 func (d *DaemonConfig) handleGlobal(w http.ResponseWriter, r *http.Request) {

--- a/volcli/volcli.go
+++ b/volcli/volcli.go
@@ -17,6 +17,7 @@ import (
 	"github.com/codegangsta/cli"
 	"github.com/contiv/errored"
 	"github.com/contiv/volplugin/config"
+	"github.com/contiv/volplugin/errors"
 	"github.com/contiv/volplugin/lock"
 	"github.com/contiv/volplugin/watch"
 	"github.com/kr/pty"
@@ -725,6 +726,18 @@ func volumeSnapshotCopy(ctx *cli.Context) (bool, error) {
 		}
 		return false, errored.Errorf("Volume %v Response Status Code was %d, not 200", qualifiedVolume, resp.StatusCode)
 	}
+
+	content, err = ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return false, errored.New("Reading body processing response").Combine(err)
+	}
+
+	vol := &config.Volume{}
+	if err := json.Unmarshal(content, vol); err != nil {
+		return false, errors.UnmarshalVolume.Combine(err)
+	}
+
+	fmt.Println(strings.Join([]string{vol.PolicyName, vol.VolumeName}, "/"))
 
 	return false, nil
 }


### PR DESCRIPTION
Fixes #413 

The snapshot copy api response was empty; the UI team would like it if it returned the volume that was created.

I have done this and also adjusted volcli to output the name of the new volume after copy.