### PR TITLE
volplugin,systemtests: make socket (aka plugin) name variable.

### DIFF
--- a/systemtests/init_test.go
+++ b/systemtests/init_test.go
@@ -39,6 +39,9 @@ func TestSystem(t *T) {
 
 func (s *systemtestSuite) SetUpTest(c *C) {
 	c.Assert(s.rebootstrap(), IsNil)
+
+	out, err := s.uploadIntent("policy1", "policy1")
+	c.Assert(err, IsNil, Commentf("output: %s", out))
 }
 
 func (s *systemtestSuite) SetUpSuite(c *C) {
@@ -68,17 +71,10 @@ func (s *systemtestSuite) SetUpSuite(c *C) {
 	c.Assert(s.waitDockerizedServices(), IsNil)
 	c.Assert(s.pullDebian(), IsNil)
 	c.Assert(s.rebootstrap(), IsNil)
-
-	out, err := s.uploadIntent("policy1", "policy1")
-	c.Assert(err, IsNil, Commentf("output: %s", out))
 }
 
 func (s *systemtestSuite) TearDownSuite(c *C) {
 	if cephDriver() && os.Getenv("NO_TEARDOWN") == "" {
 		s.clearRBD()
-	}
-
-	if os.Getenv("NO_TEARDOWN") == "" {
-		c.Assert(s.rebootstrap(), IsNil)
 	}
 }

--- a/systemtests/util_test.go
+++ b/systemtests/util_test.go
@@ -227,7 +227,7 @@ func (s *systemtestSuite) createVolume(host, volume string, opts map[string]stri
 
 	logrus.Infof("Creating %s on %q with options %q", volume, host, strings.Join(optsStr, " "))
 
-	cmd := fmt.Sprintf("docker volume create -d volplugin --name %s/%s %s", policy, name, strings.Join(optsStr, " "))
+	cmd := fmt.Sprintf("docker volume create -d volcontiv --name %s/%s %s", policy, name, strings.Join(optsStr, " "))
 
 	if out, err := s.vagrant.GetNode(host).RunCommandWithOutput(cmd); err != nil {
 		logrus.Info(string(out))

--- a/systemtests/util_test.go
+++ b/systemtests/util_test.go
@@ -28,7 +28,7 @@ var (
 
 func ClearEtcd(node remotessh.TestbedNode) {
 	logrus.Infof("Clearing etcd data")
-	node.RunCommand(`for i in $(etcdctl ls /); do etcdctl rm --recursive "$i"; done`)
+	node.RunCommand(`etcdctl rm --recursive /volplugin`)
 }
 
 // WaitForDone polls for checkDoneFn function to return true up until specified timeout

--- a/systemtests/volplugin_test.go
+++ b/systemtests/volplugin_test.go
@@ -60,7 +60,7 @@ func (s *systemtestSuite) TestVolpluginAPIServerDown(c *C) {
 func (s *systemtestSuite) TestVolpluginCleanupSocket(c *C) {
 	c.Assert(stopVolplugin(s.vagrant.GetNode("mon0")), IsNil)
 	defer c.Assert(startVolplugin(s.vagrant.GetNode("mon0")), IsNil)
-	_, err := s.mon0cmd("test -f /run/docker/plugins/volplugin.sock")
+	_, err := s.mon0cmd("test -f /run/docker/plugins/volcontiv.sock")
 	c.Assert(err, NotNil)
 }
 

--- a/systemtests/volume_test.go
+++ b/systemtests/volume_test.go
@@ -83,7 +83,7 @@ func (s *systemtestSuite) TestVolumeMultiCreateThroughDocker(c *C) {
 	c.Assert(strings.TrimSpace(out), Equals, "policy1."+volName)
 
 	c.Assert(s.vagrant.IterateNodes(func(node remotessh.TestbedNode) error {
-		return node.RunCommand("docker volume create -d volplugin --name " + fqVolName)
+		return node.RunCommand("docker volume create -d volcontiv --name " + fqVolName)
 	}), IsNil)
 
 	c.Assert(s.vagrant.IterateNodes(func(node remotessh.TestbedNode) error {

--- a/volplugin/init.go
+++ b/volplugin/init.go
@@ -44,7 +44,7 @@ func (dc *DaemonConfig) getMounted() (map[string]*storage.Mount, map[string]int,
 		for _, container := range containers {
 			if container.State == "running" {
 				for _, mount := range container.Mounts {
-					if mount.Driver == "volplugin" {
+					if mount.Driver == dc.PluginName {
 						mounts[mount.Name] = nil
 						counts[mount.Name]++
 					}

--- a/volplugin/volplugin/cli.go
+++ b/volplugin/volplugin/cli.go
@@ -27,6 +27,11 @@ func main() {
 	app.Usage = "Mount and manage Ceph RBD for containers"
 	app.Flags = []cli.Flag{
 		cli.StringFlag{
+			Name:  "plugin-name",
+			Value: "volcontiv",
+			Usage: "Name of plugin presented to docker, et al.",
+		},
+		cli.StringFlag{
 			Name:  "prefix",
 			Usage: "prefix key used in etcd for namespacing",
 			Value: "/volplugin",


### PR DESCRIPTION
This adds a flag to volplugin to change the socket name. This name is appended
to teh base plugins directory path and then suffixed with '.sock'. It will be
presented as the name provided in docker volume plugin listings, so it makes
for a nice UX.

Signed-off-by: Erik Hollensbe <github@hollensbe.org>

Fixes #399