### PR TITLE
Makefile, build: support for private registry for container images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 GUESTPREFIX=/opt/golang
 GUESTGOPATH=$(GUESTPREFIX)/src/github.com/contiv/volplugin
 GUESTBINPATH=$(GUESTPREFIX)/bin
+LOCALREGISTRY=contiv-reg:5000
+LOCALREGISTRYPATH=$(LOCALREGISTRY)/
 
 .PHONY: build
 
@@ -82,13 +84,29 @@ docker-push: docker
 	docker push contiv/volplugin
 
 clean-volplugin-containers:
-	set -e; for i in $$(seq 0 $$(($$(vagrant status | grep -cE 'mon.*running') - 1))); do vagrant ssh mon$$i -c 'docker ps | grep "volplugin" | cut -d " " -f 1 | xargs docker rm -fv'; done
+	-for i in $$(seq 0 2); do vagrant ssh mon$$i -c 'docker rm -fv volplugin volsupervisor apiserver'; done;
 
-run: build
+run: clean-volplugin-containers build
 	set -e; for i in $$(seq 0 $$(($$(vagrant status | grep -cE 'mon.*running') - 1))); do vagrant ssh mon$$i -c 'cd $(GUESTGOPATH) && ./build/scripts/build-volplugin-containers.sh && ./build/scripts/deps.sh && make run-volplugin run-apiserver'; done
 	vagrant ssh mon0 -c 'cd $(GUESTGOPATH) && make run-volsupervisor'
-	sleep 10
 	vagrant ssh mon0 -c 'connwait 127.0.0.1:9005 && volcli global upload < /testdata/globals/global1.json'
+	-for i in $$(seq 0 2); do vagrant ssh mon$$i -c 'docker rmi $$(docker images -f "dangling=true" -q)'; done;
+
+run-registry:
+	-vagrant ssh mon0 -c 'docker run -d -p 5000:5000 --restart=always --name localregistry registry'
+	vagrant ssh mon0 -c '$(GUESTGOPATH)/build/scripts/deps.sh'
+	vagrant ssh mon0 -c "$(GUESTBINPATH)/tfip2 --ip 4" | grep enp0s8: | awk '{print $$3}' | tr -d '[[:space:]]'> /tmp/contiv-reg-ip
+	set -e; for i in $$(seq 0 2); do vagrant ssh mon$$i -c "sudo -i sh -c 'grep contiv-reg /etc/hosts &>/dev/null || echo $$(cat /tmp/contiv-reg-ip) contiv-reg | sudo tee --append /etc/hosts'"; done;
+	vagrant ssh mon0 -c 'echo $(LOCALREGISTRYPATH) > /tmp/contiv-registry'
+	set -e; for i in $$(seq 0 2); do vagrant ssh mon$$i -c "sudo -i sh -c '$(GUESTGOPATH)/build/scripts/enable-private-registry.sh'"; done;
+
+run-fast: clean-volplugin-containers run-registry build
+	set -e; vagrant ssh mon0 -c 'cd $(GUESTGOPATH) && ./build/scripts/build-volplugin-containers.sh'
+	set -e; vagrant ssh mon0 -c 'docker tag contiv/volplugin $(LOCALREGISTRYPATH)contiv/volplugin && docker push $(LOCALREGISTRYPATH)contiv/volplugin'
+	set -e; for i in $$(seq 0 2); do vagrant ssh mon$$i -c 'docker pull $(LOCALREGISTRYPATH)contiv/volplugin && cd $(GUESTGOPATH) && ./build/scripts/deps.sh && make run-volplugin run-apiserver'; done
+	vagrant ssh mon0 -c 'cd $(GUESTGOPATH) && make run-volsupervisor'
+	vagrant ssh mon0 -c 'connwait 127.0.0.1:9005 && volcli global upload < /testdata/globals/global1.json'
+	-for i in $$(seq 0 2); do vagrant ssh mon$$i -c 'docker rmi $$(docker images -f "dangling=true" -q)'; done;
 
 run-etcd:
 	sudo systemctl start etcd

--- a/build/scripts/build-volplugin-containers.sh
+++ b/build/scripts/build-volplugin-containers.sh
@@ -1,17 +1,6 @@
 #!/bin/bash
 
-# In order for the new binaries to take effect we need to clean the older environment
-# Otherwise the binaries stick to older container images
-# repeated docker builds also lead to dangling images, which need to be cleaned too.
-docker ps -a | grep -e volplugin -e apiserver -e volsupervisor | awk '{print $1}' | xargs docker rm -fv
-docker rmi contiv/volplugin
-docker rmi $(docker images -f "dangling=true" -q)
-
 docker build -t contiv/volplugin .
 
 # Ensure that docker is running with MountFlags=shared
-sudo sed -i 's/MountFlags=slave/MountFlags=shared/g' /usr/lib/systemd/system/docker.service
-sudo systemctl daemon-reload
-sudo systemctl restart docker
-sleep 5
-
+sudo grep "MountFlags" /usr/lib/systemd/system/docker.service | grep "shared" &>/dev/null || sudo sed -i 's/MountFlags=slave/MountFlags=shared/g' /usr/lib/systemd/system/docker.service && sudo systemctl daemon-reload && sudo systemctl restart docker

--- a/build/scripts/contiv-vol-run.sh
+++ b/build/scripts/contiv-vol-run.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+if [ -f /tmp/contiv-registry ]; then
+	registry=$(cat /tmp/contiv-registry)
+fi
+
 set -e
 
 # Check if the container already exists
@@ -44,7 +48,7 @@ case "$1" in
         -v /lib/modules:/lib/modules:ro \
         -v /var/run/docker.sock:/var/run/docker.sock \
         -v /mnt:/mnt:shared \
-        contiv/volplugin apiserver
+        ${registry}contiv/volplugin apiserver
     ;;
 
 "volsupervisor" )
@@ -53,7 +57,7 @@ case "$1" in
         -v /lib/modules:/lib/modules:ro \
         -v /etc/ceph:/etc/ceph \
         -v /var/lib/ceph:/var/lib/ceph \
-        contiv/volplugin volsupervisor
+        ${registry}contiv/volplugin volsupervisor
     ;;
 
 "volplugin" )
@@ -68,7 +72,7 @@ case "$1" in
         -v /var/lib/ceph:/var/lib/ceph \
         -v /var/run/ceph:/var/run/ceph \
         -v /sys/fs/cgroup:/sys/fs/cgroup \
-        contiv/volplugin volplugin
+        ${registry}contiv/volplugin volplugin
     ;;
 
 * )

--- a/build/scripts/deps.sh
+++ b/build/scripts/deps.sh
@@ -2,3 +2,6 @@
 
 echo "Fetching connwait..."
 [ -n "`which connwait`" ] || sudo -E $(which go) get github.com/erikh/connwait
+
+echo "Fetching tfip2"
+[ -n "`which tfip2`" ] || sudo -E $(which go) get github.com/erikh/tfip2

--- a/build/scripts/enable-private-registry.sh
+++ b/build/scripts/enable-private-registry.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+grep insecure-registry /usr/lib/systemd/system/docker.service &>/dev/null || sed -i 's/ExecStart=.*/& --insecure-registry=contiv-reg:5000/g' /usr/lib/systemd/system/docker.service && systemctl daemon-reload && systemctl restart docker


### PR DESCRIPTION
Added `run-fast` and `run-registry` Makefile targets.
run-registry - creates a private registry and adds the necessary DOCKER_OPTS to
allow for an insecure-registry.
run-fast - build the changes on mon0, tags the images, and pushes it to private
registry on mon0. mon1 and mon2 pull this image from mon0's docker registry.
starts the processes as usual. cleans any dangling images that are left over.

conscious choices:
At multiple places the number of mon instances is fixed ($(seq 0 2)) in Makefile. Getting
this from `vagrant status` was taking time. Since, I am going to hack on this
further to see if some tasks can be parallelised. I will take care of this
hard-coding then.

Signed-off-by: Vikrant Balyan <vijayvikrant84@gmail.com>