### PR TITLE
Makefile: wait for etcd on startup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,7 @@ run-fast: clean-volplugin-containers run-registry build
 
 run-etcd:
 	sudo systemctl start etcd
+	connwait 127.0.0.1:2379
 
 docker-image:
 	docker build -t contiv/volplugin .


### PR DESCRIPTION
Will be quick-merging this if/when tests pass.

This (I think) fixes the issue with volcli global uploads not working on make restart or after etcd is terminated.