### PR TITLE
storage, config: Driver options as map[string]interface{}

### DIFF
--- a/api/impl/docker/docker_test.go
+++ b/api/impl/docker/docker_test.go
@@ -70,7 +70,7 @@ func (s *dockerSuite) TestBasic(c *C) {
 	err := s.client.PublishPolicy("policy1", &config.Policy{
 		Name:          "policy1",
 		Backend:       "ceph",
-		DriverOptions: map[string]string{"pool": "rbd"},
+		DriverOptions: map[string]interface{}{"pool": "rbd"},
 		CreateOptions: config.CreateOptions{
 			Size: "10MB",
 		},

--- a/config/policy.go
+++ b/config/policy.go
@@ -18,14 +18,14 @@ var defaultDrivers = map[string]*BackendDrivers{
 // Policy is the configuration of the policy. It includes default
 // information for items such as pool and volume configuration.
 type Policy struct {
-	Name           string            `json:"name"`
-	Unlocked       bool              `json:"unlocked,omitempty" merge:"unlocked"`
-	CreateOptions  CreateOptions     `json:"create"`
-	RuntimeOptions RuntimeOptions    `json:"runtime"`
-	DriverOptions  map[string]string `json:"driver"`
-	FileSystems    map[string]string `json:"filesystems"`
-	Backends       *BackendDrivers   `json:"backends,omitempty"`
-	Backend        string            `json:"backend,omitempty"`
+	Name           string                 `json:"name"`
+	Unlocked       bool                   `json:"unlocked,omitempty" merge:"unlocked"`
+	CreateOptions  CreateOptions          `json:"create"`
+	RuntimeOptions RuntimeOptions         `json:"runtime"`
+	DriverOptions  map[string]interface{} `json:"driver"`
+	FileSystems    map[string]string      `json:"filesystems"`
+	Backends       *BackendDrivers        `json:"backends,omitempty"`
+	Backend        string                 `json:"backend,omitempty"`
 }
 
 // BackendDrivers is a struct containing all the drivers used under this policy

--- a/config/policy_test.go
+++ b/config/policy_test.go
@@ -10,7 +10,7 @@ var testPolicies = map[string]*Policy{
 			Mount:    "ceph",
 			Snapshot: "ceph",
 		},
-		DriverOptions: map[string]string{"pool": "rbd"},
+		DriverOptions: map[string]interface{}{"pool": "rbd"},
 		CreateOptions: CreateOptions{
 			Size:       "10MB",
 			FileSystem: defaultFilesystem,
@@ -31,7 +31,7 @@ var testPolicies = map[string]*Policy{
 			Mount:    "ceph",
 			Snapshot: "ceph",
 		},
-		DriverOptions: map[string]string{"pool": "rbd"},
+		DriverOptions: map[string]interface{}{"pool": "rbd"},
 		CreateOptions: CreateOptions{
 			Size:       "20MB",
 			FileSystem: defaultFilesystem,
@@ -45,7 +45,7 @@ var testPolicies = map[string]*Policy{
 			Mount:    "ceph",
 			Snapshot: "ceph",
 		},
-		DriverOptions: map[string]string{"pool": "rbd"},
+		DriverOptions: map[string]interface{}{"pool": "rbd"},
 		CreateOptions: CreateOptions{
 			Size:       "0",
 			FileSystem: defaultFilesystem,
@@ -59,7 +59,7 @@ var testPolicies = map[string]*Policy{
 			Mount:    "ceph",
 			Snapshot: "ceph",
 		},
-		DriverOptions: map[string]string{"pool": "rbd"},
+		DriverOptions: map[string]interface{}{"pool": "rbd"},
 		CreateOptions: CreateOptions{
 			Size:       "20MB",
 			FileSystem: defaultFilesystem,
@@ -73,7 +73,7 @@ var testPolicies = map[string]*Policy{
 			Mount:    "ceph",
 			Snapshot: "ceph",
 		},
-		DriverOptions: map[string]string{"pool": "rbd"},
+		DriverOptions: map[string]interface{}{"pool": "rbd"},
 		CreateOptions: CreateOptions{
 			Size:       "not a number",
 			FileSystem: defaultFilesystem,
@@ -87,7 +87,7 @@ var testPolicies = map[string]*Policy{
 			Mount:    "ceph",
 			Snapshot: "ceph",
 		},
-		DriverOptions: map[string]string{"pool": "rbd"},
+		DriverOptions: map[string]interface{}{"pool": "rbd"},
 		CreateOptions: CreateOptions{
 			Size:       "10MB",
 			FileSystem: defaultFilesystem,
@@ -106,7 +106,7 @@ var testPolicies = map[string]*Policy{
 			Mount: "ceph",
 		},
 		Name:          "blanksize",
-		DriverOptions: map[string]string{"pool": "rbd"},
+		DriverOptions: map[string]interface{}{"pool": "rbd"},
 		CreateOptions: CreateOptions{
 			FileSystem: defaultFilesystem,
 		},
@@ -119,7 +119,7 @@ var testPolicies = map[string]*Policy{
 			Mount: "ceph",
 		},
 		Name:          "blanksize",
-		DriverOptions: map[string]string{"pool": "rbd"},
+		DriverOptions: map[string]interface{}{"pool": "rbd"},
 		CreateOptions: CreateOptions{
 			FileSystem: defaultFilesystem,
 		},
@@ -128,7 +128,7 @@ var testPolicies = map[string]*Policy{
 	},
 	"nobackend": {
 		Name:          "nobackend",
-		DriverOptions: map[string]string{"pool": "rbd"},
+		DriverOptions: map[string]interface{}{"pool": "rbd"},
 		CreateOptions: CreateOptions{
 			Size:       "10MB",
 			FileSystem: defaultFilesystem,

--- a/config/validation_test.go
+++ b/config/validation_test.go
@@ -7,7 +7,7 @@ var (
 	VolumeConfigs   = map[string]map[string]*Volume{
 		"valid": {
 			"basic": {
-				DriverOptions:  map[string]string{"pool": "rbd"},
+				DriverOptions:  map[string]interface{}{"pool": "rbd"},
 				CreateOptions:  CreateOptions{Size: "10MB"},
 				RuntimeOptions: RuntimeOptions{UseSnapshots: false},
 				VolumeName:     "basicvolume",
@@ -15,7 +15,7 @@ var (
 				Backends:       defaultBackends,
 			},
 			"basicwithruntime": {
-				DriverOptions:  map[string]string{"pool": "rbd"},
+				DriverOptions:  map[string]interface{}{"pool": "rbd"},
 				CreateOptions:  CreateOptions{Size: "10MB"},
 				RuntimeOptions: RuntimeOptions{UseSnapshots: true, Snapshot: SnapshotConfig{Frequency: "10m", Keep: 10}},
 				VolumeName:     "basicvolume",

--- a/config/volume.go
+++ b/config/volume.go
@@ -22,14 +22,14 @@ import (
 // Volume is the configuration of the policy. It includes pool and
 // snapshot information.
 type Volume struct {
-	PolicyName     string            `json:"policy"`
-	VolumeName     string            `json:"name"`
-	Unlocked       bool              `json:"unlocked,omitempty" merge:"unlocked"`
-	DriverOptions  map[string]string `json:"driver"`
-	MountSource    string            `json:"mount" merge:"mount"`
-	CreateOptions  CreateOptions     `json:"create"`
-	RuntimeOptions RuntimeOptions    `json:"runtime"`
-	Backends       *BackendDrivers   `json:"backends,omitempty"`
+	PolicyName     string                 `json:"policy"`
+	VolumeName     string                 `json:"name"`
+	Unlocked       bool                   `json:"unlocked,omitempty" merge:"unlocked"`
+	DriverOptions  map[string]interface{} `json:"driver"`
+	MountSource    string                 `json:"mount" merge:"mount"`
+	CreateOptions  CreateOptions          `json:"create"`
+	RuntimeOptions RuntimeOptions         `json:"runtime"`
+	Backends       *BackendDrivers        `json:"backends,omitempty"`
 }
 
 // CreateOptions are the set of options used by apiserver during the volume
@@ -102,7 +102,7 @@ func (c *Client) CreateVolume(rc *VolumeRequest) (*Volume, error) {
 	}
 
 	if resp.DriverOptions == nil {
-		resp.DriverOptions = map[string]string{}
+		resp.DriverOptions = map[string]interface{}{}
 	}
 
 	if err := resp.Validate(); err != nil {

--- a/config/volume_test.go
+++ b/config/volume_test.go
@@ -45,7 +45,7 @@ func (s *configSuite) TestVolumeValidate(c *C) {
 	c.Assert(vc.Validate(), NotNil)
 
 	vc = &Volume{
-		DriverOptions:  map[string]string{"pool": "rbd"},
+		DriverOptions:  map[string]interface{}{"pool": "rbd"},
 		CreateOptions:  CreateOptions{Size: "10MB"},
 		RuntimeOptions: RuntimeOptions{UseSnapshots: false},
 		VolumeName:     "",
@@ -55,7 +55,7 @@ func (s *configSuite) TestVolumeValidate(c *C) {
 	c.Assert(vc.Validate(), NotNil)
 
 	vc = &Volume{
-		DriverOptions:  map[string]string{"pool": "rbd"},
+		DriverOptions:  map[string]interface{}{"pool": "rbd"},
 		CreateOptions:  CreateOptions{Size: "10MB"},
 		RuntimeOptions: RuntimeOptions{UseSnapshots: false},
 		VolumeName:     "foo",
@@ -70,7 +70,7 @@ func (s *configSuite) TestVolumeValidate(c *C) {
 			Snapshot: "ceph",
 			CRUD:     "ceph",
 		},
-		DriverOptions:  map[string]string{"pool": "rbd"},
+		DriverOptions:  map[string]interface{}{"pool": "rbd"},
 		CreateOptions:  CreateOptions{Size: "10MB"},
 		RuntimeOptions: RuntimeOptions{UseSnapshots: false},
 		VolumeName:     "foo",

--- a/db/structs.go
+++ b/db/structs.go
@@ -7,14 +7,14 @@ import (
 // Policy is the configuration of the policy. It includes default
 // information for items such as pool and volume configuration.
 type Policy struct {
-	Name           string            `json:"name"`
-	Unlocked       bool              `json:"unlocked,omitempty" merge:"unlocked"`
-	CreateOptions  CreateOptions     `json:"create"`
-	RuntimeOptions *RuntimeOptions   `json:"runtime"`
-	DriverOptions  map[string]string `json:"driver"`
-	FileSystems    map[string]string `json:"filesystems"`
-	Backends       *BackendDrivers   `json:"backends,omitempty"`
-	Backend        string            `json:"backend,omitempty"`
+	Name           string                 `json:"name"`
+	Unlocked       bool                   `json:"unlocked,omitempty" merge:"unlocked"`
+	CreateOptions  CreateOptions          `json:"create"`
+	RuntimeOptions *RuntimeOptions        `json:"runtime"`
+	DriverOptions  map[string]interface{} `json:"driver"`
+	FileSystems    map[string]string      `json:"filesystems"`
+	Backends       *BackendDrivers        `json:"backends,omitempty"`
+	Backend        string                 `json:"backend,omitempty"`
 }
 
 // BackendDrivers is a struct containing all the drivers used under this policy
@@ -73,14 +73,14 @@ type UseLocker interface {
 // Volume is the configuration of the policy. It includes pool and
 // snapshot information.
 type Volume struct {
-	PolicyName     string            `json:"policy"`
-	VolumeName     string            `json:"name"`
-	Unlocked       bool              `json:"unlocked,omitempty" merge:"unlocked"`
-	DriverOptions  map[string]string `json:"driver"`
-	MountSource    string            `json:"mount" merge:"mount"`
-	CreateOptions  CreateOptions     `json:"create"`
-	RuntimeOptions *RuntimeOptions   `json:"runtime"`
-	Backends       *BackendDrivers   `json:"backends,omitempty"`
+	PolicyName     string                 `json:"policy"`
+	VolumeName     string                 `json:"name"`
+	Unlocked       bool                   `json:"unlocked,omitempty" merge:"unlocked"`
+	DriverOptions  map[string]interface{} `json:"driver"`
+	MountSource    string                 `json:"mount" merge:"mount"`
+	CreateOptions  CreateOptions          `json:"create"`
+	RuntimeOptions *RuntimeOptions        `json:"runtime"`
+	Backends       *BackendDrivers        `json:"backends,omitempty"`
 }
 
 // CreateOptions are the set of options used by apiserver during the volume

--- a/db/test/policy_test.go
+++ b/db/test/policy_test.go
@@ -13,7 +13,7 @@ var testPolicies = map[string]*db.Policy{
 			Mount:    "ceph",
 			Snapshot: "ceph",
 		},
-		DriverOptions: map[string]string{"pool": "rbd"},
+		DriverOptions: map[string]interface{}{"pool": "rbd"},
 		CreateOptions: db.CreateOptions{
 			Size:       "10MB",
 			FileSystem: db.DefaultFilesystem,
@@ -34,7 +34,7 @@ var testPolicies = map[string]*db.Policy{
 			Mount:    "ceph",
 			Snapshot: "ceph",
 		},
-		DriverOptions: map[string]string{"pool": "rbd"},
+		DriverOptions: map[string]interface{}{"pool": "rbd"},
 		CreateOptions: db.CreateOptions{
 			Size:       "20MB",
 			FileSystem: db.DefaultFilesystem,
@@ -49,7 +49,7 @@ var testPolicies = map[string]*db.Policy{
 			Mount:    "ceph",
 			Snapshot: "ceph",
 		},
-		DriverOptions: map[string]string{"pool": "rbd"},
+		DriverOptions: map[string]interface{}{"pool": "rbd"},
 		CreateOptions: db.CreateOptions{
 			Size:       "0",
 			FileSystem: db.DefaultFilesystem,
@@ -63,7 +63,7 @@ var testPolicies = map[string]*db.Policy{
 			Mount:    "ceph",
 			Snapshot: "ceph",
 		},
-		DriverOptions: map[string]string{"pool": "rbd"},
+		DriverOptions: map[string]interface{}{"pool": "rbd"},
 		CreateOptions: db.CreateOptions{
 			Size:       "not a number",
 			FileSystem: db.DefaultFilesystem,
@@ -77,7 +77,7 @@ var testPolicies = map[string]*db.Policy{
 			Mount:    "ceph",
 			Snapshot: "ceph",
 		},
-		DriverOptions: map[string]string{"pool": "rbd"},
+		DriverOptions: map[string]interface{}{"pool": "rbd"},
 		CreateOptions: db.CreateOptions{
 			Size:       "10MB",
 			FileSystem: db.DefaultFilesystem,
@@ -96,7 +96,7 @@ var testPolicies = map[string]*db.Policy{
 			Mount: "ceph",
 		},
 		Name:          "blanksize",
-		DriverOptions: map[string]string{"pool": "rbd"},
+		DriverOptions: map[string]interface{}{"pool": "rbd"},
 		CreateOptions: db.CreateOptions{
 			FileSystem: db.DefaultFilesystem,
 		},
@@ -109,7 +109,7 @@ var testPolicies = map[string]*db.Policy{
 			Mount: "ceph",
 		},
 		Name:          "blanksize",
-		DriverOptions: map[string]string{"pool": "rbd"},
+		DriverOptions: map[string]interface{}{"pool": "rbd"},
 		CreateOptions: db.CreateOptions{
 			FileSystem: db.DefaultFilesystem,
 		},
@@ -118,7 +118,7 @@ var testPolicies = map[string]*db.Policy{
 	},
 	"nobackend": {
 		Name:          "nobackend",
-		DriverOptions: map[string]string{"pool": "rbd"},
+		DriverOptions: map[string]interface{}{"pool": "rbd"},
 		CreateOptions: db.CreateOptions{
 			Size:       "10MB",
 			FileSystem: db.DefaultFilesystem,

--- a/db/test/volume_test.go
+++ b/db/test/volume_test.go
@@ -145,7 +145,7 @@ func (s *testSuite) TestVolumeValidate(c *C) {
 	c.Assert(vc.Validate(), NotNil)
 
 	vc = &db.Volume{
-		DriverOptions:  map[string]string{"pool": "rbd"},
+		DriverOptions:  map[string]interface{}{"pool": "rbd"},
 		CreateOptions:  db.CreateOptions{Size: "10MB"},
 		RuntimeOptions: &db.RuntimeOptions{UseSnapshots: false},
 		VolumeName:     "",
@@ -155,7 +155,7 @@ func (s *testSuite) TestVolumeValidate(c *C) {
 	c.Assert(vc.Validate(), NotNil)
 
 	vc = &db.Volume{
-		DriverOptions:  map[string]string{"pool": "rbd"},
+		DriverOptions:  map[string]interface{}{"pool": "rbd"},
 		CreateOptions:  db.CreateOptions{Size: "10MB"},
 		RuntimeOptions: &db.RuntimeOptions{UseSnapshots: false},
 		VolumeName:     "foo",
@@ -170,7 +170,7 @@ func (s *testSuite) TestVolumeValidate(c *C) {
 			Snapshot: "ceph",
 			CRUD:     "ceph",
 		},
-		DriverOptions:  map[string]string{"pool": "rbd"},
+		DriverOptions:  map[string]interface{}{"pool": "rbd"},
 		CreateOptions:  db.CreateOptions{Size: "10MB"},
 		RuntimeOptions: &db.RuntimeOptions{UseSnapshots: false},
 		VolumeName:     "foo",

--- a/db/volume.go
+++ b/db/volume.go
@@ -39,7 +39,7 @@ func CreateVolume(vr *VolumeRequest) (*Volume, error) {
 	}
 
 	if vr.Policy.DriverOptions == nil {
-		vr.Policy.DriverOptions = map[string]string{}
+		vr.Policy.DriverOptions = map[string]interface{}{}
 	}
 
 	if err := vr.Policy.Validate(); err != nil {

--- a/storage/backend/ceph/ceph_test.go
+++ b/storage/backend/ceph/ceph_test.go
@@ -230,7 +230,9 @@ again:
 	for i := 0; i < 10; i++ {
 		_, err := mountDrv.Mount(driverOpts)
 		c.Assert(err, IsNil)
-		s.readWriteTest(c, fmt.Sprintf("/mnt/ceph/%s/test.pithos", driverOpts.Volume.Params["pool"]))
+		poolName, err := driverOpts.Volume.Params.Get("pool", false)
+		c.Assert(err, IsNil)
+		s.readWriteTest(c, fmt.Sprintf("/mnt/ceph/%s/test.pithos", poolName))
 		c.Assert(mountDrv.Unmount(driverOpts), IsNil)
 	}
 	c.Assert(crudDrv.Destroy(driverOpts), IsNil)
@@ -290,12 +292,15 @@ again:
 	intName, err := (&Driver{}).internalName(driverOpts.Volume.Name) // totally cheating
 	c.Assert(err, IsNil)
 
+	poolName, err := driverOpts.Volume.Params.Get("pool", false)
+	c.Assert(err, IsNil)
+
 	(*mounts[0]).Volume.Size = 10 // correct this value even though it is an unnecessary value returned
 	c.Assert(*mounts[0], DeepEquals, storage.Mount{
 		Device:   "/dev/rbd0",
 		DevMajor: 252,
 		DevMinor: 0,
-		Path:     strings.Join([]string{myMountpath, driverOpts.Volume.Params["pool"], intName}, "/"),
+		Path:     strings.Join([]string{myMountpath, poolName, intName}, "/"),
 		Volume:   driverOpts.Volume,
 	})
 
@@ -356,13 +361,16 @@ func (s *cephSuite) TestSnapshotClone(c *C) {
 
 again:
 
+	poolName, err := driverOpts.Volume.Params.Get("pool", false)
+	c.Assert(err, IsNil)
+
 	c.Assert(crudDrv.Create(driverOpts), IsNil)
 	c.Assert(snapDrv.CreateSnapshot("test", driverOpts), IsNil)
 	c.Assert(snapDrv.CreateSnapshot("testsnap", driverOpts), IsNil)
 	c.Assert(snapDrv.CopySnapshot(driverOpts, "testsnap", "test/image"), IsNil)
 	c.Assert(snapDrv.CopySnapshot(driverOpts, "test", "test/image"), NotNil)
 
-	content, err := exec.Command("rbd", "ls", driverOpts.Volume.Params["pool"]).CombinedOutput()
+	content, err := exec.Command("rbd", "ls", poolName).CombinedOutput()
 	c.Assert(err, IsNil)
 	c.Assert(strings.TrimSpace(string(content)), Equals, "test.image\ntest.pithos")
 	c.Assert(snapDrv.CopySnapshot(driverOpts, "foo", "test/image"), NotNil)
@@ -370,8 +378,8 @@ again:
 
 	driverOpts.Volume.Name = "test/image"
 	c.Assert(crudDrv.Destroy(driverOpts), IsNil)
-	exec.Command("rbd", "snap", "unprotect", mkpool(driverOpts.Volume.Params["pool"], "test.pithos"), "--snap", "test").Run()
-	exec.Command("rbd", "snap", "unprotect", mkpool(driverOpts.Volume.Params["pool"], "test.pithos"), "--snap", "testsnap").Run()
+	exec.Command("rbd", "snap", "unprotect", mkpool(poolName, "test.pithos"), "--snap", "test").Run()
+	exec.Command("rbd", "snap", "unprotect", mkpool(poolName, "test.pithos"), "--snap", "testsnap").Run()
 	driverOpts.Volume.Name = "test/pithos"
 	c.Assert(crudDrv.Destroy(driverOpts), IsNil)
 

--- a/storage/backend/ceph/internals.go
+++ b/storage/backend/ceph/internals.go
@@ -23,7 +23,11 @@ type rbdMap map[string]struct {
 }
 
 func (c *Driver) mapImage(do storage.DriverOptions) (string, error) {
-	poolName := do.Volume.Params["pool"]
+	poolName, err := do.Volume.Params.Get("pool", false)
+	if err != nil {
+		return "", err
+	}
+
 	intName, err := c.internalName(do.Volume.Name)
 	if err != nil {
 		return "", err
@@ -52,14 +56,14 @@ retry:
 	}
 
 	for _, rbd := range rbdmap {
-		if rbd.Name == intName && rbd.Pool == do.Volume.Params["pool"] {
+		if rbd.Name == intName && rbd.Pool == poolName {
 			device = rbd.Device
 			break
 		}
 	}
 
 	if device == "" {
-		return "", errored.Errorf("Volume %s in pool %s not found in RBD showmapped output", intName, do.Volume.Params["pool"])
+		return "", errored.Errorf("Volume %s in pool %s not found in RBD showmapped output", intName, poolName)
 	}
 
 	logrus.Debugf("mapped volume %q as %q", intName, device)
@@ -101,7 +105,10 @@ func (c *Driver) unmapImage(do storage.DriverOptions) error {
 }
 
 func (c *Driver) doUnmap(do storage.DriverOptions, rbdmap rbdMap) (bool, error) {
-	poolName := do.Volume.Params["pool"]
+	poolName, err := do.Volume.Params.Get("pool", false)
+	if err != nil {
+		return false, err
+	}
 
 	intName, err := c.internalName(do.Volume.Name)
 	if err != nil {
@@ -109,7 +116,7 @@ func (c *Driver) doUnmap(do storage.DriverOptions, rbdmap rbdMap) (bool, error) 
 	}
 
 	for _, rbd := range rbdmap {
-		if rbd.Name == intName && rbd.Pool == do.Volume.Params["pool"] {
+		if rbd.Name == intName && rbd.Pool == poolName {
 			logrus.Debugf("Unmapping volume %s/%s at device %q", poolName, intName, strings.TrimSpace(rbd.Device))
 
 			if _, err := os.Stat(rbd.Device); err != nil {
@@ -187,7 +194,7 @@ func (c *Driver) getMapped(timeout time.Duration) ([]*storage.Mount, error) {
 			Device: rbd.Device,
 			Volume: storage.Volume{
 				Name: c.externalName(rbd.Name),
-				Params: map[string]string{
+				Params: map[string]interface{}{
 					"pool": rbd.Pool,
 				},
 			},

--- a/storage/backend/ceph/util.go
+++ b/storage/backend/ceph/util.go
@@ -13,7 +13,13 @@ func (c *Driver) MountPath(do storage.DriverOptions) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(c.mountpath, do.Volume.Params["pool"], volName), nil
+
+	poolName, err := do.Volume.Params.Get("pool", false)
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(c.mountpath, poolName, volName), nil
 }
 
 // FIXME maybe this belongs in storage/ as it's more general?

--- a/storage/backend/nfs/mount.go
+++ b/storage/backend/nfs/mount.go
@@ -35,7 +35,7 @@ func (d *Driver) Mounted(timeout time.Duration) ([]*storage.Mount, error) {
 			Path:     hostMount.MountPoint,
 			Volume: storage.Volume{
 				Name: rel,
-				Params: map[string]string{
+				Params: map[string]interface{}{
 					"mount": hostMount.MountSource,
 				},
 			},

--- a/storage/backend/nfs/nfs.go
+++ b/storage/backend/nfs/nfs.go
@@ -80,7 +80,12 @@ func (d *Driver) mapOptionsToString(mapOpts map[string]string) string {
 }
 
 func (d *Driver) mkOpts(do storage.DriverOptions) (string, error) {
-	mapOpts, err := d.validateConvertOptions(do.Volume.Params["options"])
+	options, err := do.Volume.Params.Get("options", true)
+	if err != nil {
+		return "", err
+	}
+
+	mapOpts, err := d.validateConvertOptions(options)
 	if err != nil {
 		return "", err
 	}

--- a/storage/driver.go
+++ b/storage/driver.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"errors"
+	"strings"
 	"time"
 
 	"github.com/contiv/errored"
@@ -13,7 +14,7 @@ var (
 )
 
 // Params are parameters that relate directly to the location of the storage.
-type Params map[string]string
+type Params map[string]interface{}
 
 // A Mount is the resulting attributes of a Mount or Unmount operation.
 type Mount struct {
@@ -145,4 +146,20 @@ func (v Volume) Validate() error {
 	}
 
 	return nil
+}
+
+// Get can be used to get only "string" types from element `driver`
+func (p Params) Get(attr string, allowEmpty bool) (string, error) {
+	switch value := p[attr].(type) {
+	case string:
+		if !allowEmpty && len(strings.TrimSpace(value)) == 0 {
+			return "", errored.Errorf("Expected non-empty string for driver.%s", attr)
+		}
+		return value, nil
+	default:
+		if allowEmpty && value == nil {
+			return "", nil
+		}
+		return "", errored.Errorf("Expected string type for driver.%s", attr)
+	}
 }

--- a/storage/driver_test.go
+++ b/storage/driver_test.go
@@ -17,7 +17,7 @@ func (s *storageSuite) TestDriverOptionsValidate(c *C) {
 
 	c.Assert(do.Validate(), NotNil)
 
-	do = DriverOptions{Timeout: 1, Volume: Volume{Name: "hi", Params: map[string]string{}}}
+	do = DriverOptions{Timeout: 1, Volume: Volume{Name: "hi", Params: map[string]interface{}{}}}
 	c.Assert(do.Validate(), IsNil)
 	do.Timeout = 0
 	c.Assert(do.Validate(), NotNil)
@@ -29,13 +29,13 @@ func (s *storageSuite) TestVolumeValidate(c *C) {
 	v := Volume{}
 	c.Assert(v.Validate(), NotNil)
 
-	v = Volume{Name: "name", Size: 100, Params: map[string]string{}}
+	v = Volume{Name: "name", Size: 100, Params: map[string]interface{}{}}
 	c.Assert(v.Validate(), IsNil)
 	v.Name = ""
 	c.Assert(v.Validate(), NotNil)
 	v.Name = "name"
 	v.Params = nil
 	c.Assert(v.Validate(), NotNil)
-	v.Params = map[string]string{}
+	v.Params = map[string]interface{}{}
 	c.Assert(v.Validate(), IsNil)
 }


### PR DESCRIPTION
This will let the DriverOptions to accept any data type. Helps new storage driver integrations.

Signed-off-by: Yuva Shankar <yuva.shankar29@gmail.com>