### PR TITLE
db: New Locking API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ clean:
 clean-vms:
 	@echo DO NOT USE THIS COMMAND UNLESS YOU ABSOLUTELY HAVE TO. PRESS CTRL-C NOW.
 	@sleep 20
+	pkill -9 VBoxHeadless
 	for i in $$(vboxmanage list vms | grep volplugin | awk '{ print $$2 }'); do vboxmanage controlvm "$$i" poweroff; vboxmanage unregistervm "$$i"; done
 	make clean
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -132,6 +132,7 @@ ansible_provision = proc do |ansible|
 
   # In a production deployment, these should be secret
   ansible.extra_vars = {
+    etcd_version: "v3.0.6",
     scheduler_provider: ENV["UCP"] ? "ucp-swarm" : "native-swarm",
     ucp_bootstrap_node_name: "mon0",
     ucp_license_remote: ENV["HOME"] + "/docker_subscription.lic",

--- a/config/util_test.go
+++ b/config/util_test.go
@@ -9,8 +9,21 @@ import (
 
 func stopStartEtcd(c *C, f func()) {
 	c.Assert(exec.Command("/bin/sh", "-c", "sudo systemctl stop etcd").Run(), IsNil)
-	time.Sleep(time.Second)
+	for {
+		if err := exec.Command("/bin/sh", "-c", "etcdctl cluster-health").Run(); err != nil {
+			break
+		}
+
+		time.Sleep(time.Second / 4)
+	}
+
 	f()
+
 	c.Assert(exec.Command("/bin/sh", "-c", "sudo systemctl start etcd").Run(), IsNil)
-	time.Sleep(15 * time.Second)
+	for {
+		if err := exec.Command("/bin/sh", "-c", "etcdctl cluster-health").Run(); err == nil {
+			break
+		}
+		time.Sleep(time.Second / 4)
+	}
 }

--- a/db/db.go
+++ b/db/db.go
@@ -1,6 +1,9 @@
 package db
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+)
 
 /*
 
@@ -51,6 +54,24 @@ type Client interface {
 
 	// ListPrefix lists all the entities under prefix instead of listing the whole keyspace.
 	ListPrefix(string, Entity) ([]Entity, error)
+
+	// Acquire and permanently hold a lock. Attempts until timeout.
+	Acquire(Lock) error
+
+	// AcquireWithTTL holds a lock with an expiration TTL. Attempts only once.
+	AcquireWithTTL(Lock, time.Duration) error
+
+	// Free a lock. Passing true as the second parameter will force the removal.
+	Free(Lock, bool) error
+
+	// AcquireAndRefresh starts a goroutine to refresh the key every 1/4
+	// (jittered) of the TTL. A stop channel is returned which, when sent a
+	// struct, will terminate the refresh. Error is returned for anything that
+	// might occur while setting up the goroutine.
+	//
+	// Do not use Free to free these locks, it will not work! Use the stop
+	// channel.
+	AcquireAndRefresh(Lock, time.Duration) (chan struct{}, error)
 }
 
 // Entity provides an abstraction on our types and how they are persisted to
@@ -80,6 +101,24 @@ type Entity interface {
 	Hooks() *Hooks
 
 	fmt.Stringer
+}
+
+// Lock is an interface to types used to establish locks.
+type Lock interface {
+	// Owner is the consumer of the lock, typically a hostname.
+	Owner() string
+
+	// Reason is the reason we're taking this lock. This is used typically to
+	// enforce that two different operations do not happen at the same time. The
+	// user + reason + path equates to a unique lock.
+	Reason() string
+
+	// MayExist indicates a lock may already exist for a given type; locks still
+	// must pass a content check. this is only consulted if the key previously
+	// exists.
+	MayExist() bool
+
+	Entity
 }
 
 // Hook is the type that represents a client hook in our entities system. Hooks

--- a/db/policy.go
+++ b/db/policy.go
@@ -84,9 +84,14 @@ func (p *Policy) Copy() Entity {
 	// XXX backends are special. They are optional and making them empty results in
 	// a nil pointer. However, in this copy we don't want to copy a pointer, just
 	// the data if it exists.
-	if p2.Backends != nil {
+	if p.Backends != nil {
 		b2 := *p.Backends
 		p2.Backends = &b2
+	}
+
+	if p.RuntimeOptions != nil {
+		ro2 := *p.RuntimeOptions
+		p2.RuntimeOptions = &ro2
 	}
 
 	return &p2

--- a/db/test/entities_test.go
+++ b/db/test/entities_test.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	. "testing"
 
@@ -9,6 +10,7 @@ import (
 
 	. "gopkg.in/check.v1"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/contiv/errored"
 	"github.com/contiv/volplugin/db"
 	"github.com/contiv/volplugin/db/impl/etcd"
@@ -27,8 +29,12 @@ var _ = Suite(&testSuite{})
 func TestDB(t *T) { TestingT(t) }
 
 func (s *testSuite) SetUpTest(c *C) {
-	errored.AlwaysDebug = true
-	errored.AlwaysTrace = true
+	if os.Getenv("DEBUG") != "" {
+		errored.AlwaysDebug = true
+		errored.AlwaysTrace = true
+		logrus.SetLevel(logrus.DebugLevel)
+	}
+
 	exec.Command("/bin/sh", "-c", "etcdctl rm --recursive /volplugin /testing /test /watch").Run()
 	var err error
 	s.client, err = etcd.NewClient(etcdHosts, "volplugin")

--- a/db/test/entity_test.go
+++ b/db/test/entity_test.go
@@ -60,3 +60,64 @@ func (t *testEntity) Copy() db.Entity {
 func (t *testEntity) Hooks() *db.Hooks {
 	return t.hooks
 }
+
+type testLock struct {
+	owner    string
+	reason   string
+	name     string
+	mayExist bool
+}
+
+func newLock(mayExist bool, owner, reason, name string) *testLock {
+	return &testLock{owner: owner, reason: reason, name: name, mayExist: mayExist}
+}
+
+func (t *testLock) String() string {
+	return t.name
+}
+
+func (t *testLock) SetKey(key string) error {
+	t.name = strings.Trim(strings.TrimPrefix(strings.Trim(key, "/"), t.Prefix()), "/")
+	return nil
+}
+
+func (t *testLock) Read(b []byte) error {
+	return json.Unmarshal(b, t)
+}
+
+func (t *testLock) Write() ([]byte, error) {
+	return json.Marshal(t)
+}
+
+func (t *testLock) Path() (string, error) {
+	return strings.Join([]string{t.Prefix(), t.name}, "/"), nil
+}
+
+func (t *testLock) Prefix() string {
+	return "test"
+}
+
+func (t *testLock) Validate() error {
+	return nil
+}
+
+func (t *testLock) Copy() db.Entity {
+	t2 := *t
+	return &t2
+}
+
+func (t *testLock) Hooks() *db.Hooks {
+	return &db.Hooks{}
+}
+
+func (t *testLock) Owner() string {
+	return t.owner
+}
+
+func (t *testLock) Reason() string {
+	return t.reason
+}
+
+func (t *testLock) MayExist() bool {
+	return t.mayExist
+}

--- a/db/test/lock_test.go
+++ b/db/test/lock_test.go
@@ -1,0 +1,160 @@
+package test
+
+import (
+	"strings"
+	"time"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/contiv/volplugin/db"
+	. "gopkg.in/check.v1"
+)
+
+func (s *testSuite) TestLockAcquire(c *C) {
+	copy := testPolicies["basic"].Copy()
+	copy.(*db.Policy).Name = "policy1"
+	c.Assert(s.client.Set(copy), IsNil)
+
+	v, err := db.CreateVolume(&db.VolumeRequest{Policy: copy.(*db.Policy), Name: "test"})
+	c.Assert(err, IsNil, Commentf("%v", v))
+	c.Assert(s.client.Set(v), IsNil)
+
+	lock := db.NewCreateOwner("mon0", v)
+
+	path, err := lock.Path()
+	c.Assert(err, IsNil)
+	c.Assert(path, Equals, strings.Join([]string{lock.Prefix(), v.String()}, "/"))
+	c.Assert(lock.Prefix(), Equals, "users/volume")
+	c.Assert(s.client.Acquire(lock), IsNil)
+
+	testUse := db.NewUse(v)
+	c.Assert(s.client.Get(testUse), IsNil)
+
+	// test that we can acquire the fetched lock.
+	path, err = testUse.Path()
+	c.Assert(err, IsNil)
+	c.Assert(path, Equals, strings.Join([]string{lock.Prefix(), v.String()}, "/"))
+	c.Assert(lock.Prefix(), Equals, "users/volume")
+	c.Assert(s.client.Acquire(lock), IsNil)
+
+	lock2 := db.NewCreateOwner("mon1", v)
+	c.Assert(s.client.Free(lock2, false), NotNil)
+
+	c.Assert(s.client.Free(lock, false), IsNil)
+	c.Assert(s.client.Acquire(lock2), IsNil)
+	c.Assert(s.client.Free(lock2, false), IsNil)
+
+	c.Assert(s.client.Acquire(lock), IsNil)
+	c.Assert(s.client.Free(lock2, true), IsNil)
+}
+
+func (s *testSuite) TestLockBattery(c *C) {
+	copy := testPolicies["basic"].Copy()
+	copy.(*db.Policy).Name = "policy1"
+	c.Assert(s.client.Set(copy), IsNil)
+
+	v, err := db.CreateVolume(&db.VolumeRequest{Policy: copy.(*db.Policy), Name: "test"})
+	c.Assert(err, IsNil, Commentf("%v", v))
+	c.Assert(s.client.Set(v), IsNil)
+
+	lock := db.NewCreateOwner("mon0", v)
+	c.Assert(s.client.Acquire(lock), IsNil)
+
+	// go routine A should never free the lock.
+	// go routine B should never succeed at acquiring it.
+
+	syncChan := make(chan struct{})
+
+	defer func(lock db.Lock) {
+		syncChan <- struct{}{} // this relays to the first one to ensure the lock is freed
+		s.client.Free(lock, true)
+	}(lock)
+
+	go func(v *db.Volume) {
+		for {
+			select {
+			case <-syncChan:
+				return
+			default:
+				lock := db.NewCreateOwner("mon0", v)
+				c.Assert(s.client.Acquire(lock), IsNil)
+			}
+		}
+	}(v)
+
+	go func(v *db.Volume) {
+		for {
+			select {
+			case <-syncChan:
+				syncChan <- struct{}{}
+				return
+			default:
+				lock := db.NewCreateOwner("mon1", v)
+				c.Assert(s.client.Acquire(lock), NotNil)
+			}
+		}
+	}(v)
+
+	logrus.Info("Creating contention in etcd")
+	time.Sleep(time.Minute)
+}
+
+func (s *testSuite) TestLockTTL(c *C) {
+	copy := testPolicies["basic"].Copy()
+	copy.(*db.Policy).Name = "policy1"
+	c.Assert(s.client.Set(copy), IsNil)
+
+	v, err := db.CreateVolume(&db.VolumeRequest{Policy: copy.(*db.Policy), Name: "test"})
+	c.Assert(err, IsNil, Commentf("%v", v))
+	c.Assert(s.client.Set(v), IsNil)
+
+	lock := db.NewCreateOwner("mon0", v)
+	lock2 := db.NewCreateOwner("mon1", v)
+
+	s.client.Free(lock, true)
+	c.Assert(s.client.AcquireWithTTL(lock, time.Second), IsNil)
+	c.Assert(s.client.AcquireWithTTL(lock2, time.Second), NotNil)
+
+	time.Sleep(2 * time.Second) // wait for ttl to expire
+
+	c.Assert(s.client.AcquireWithTTL(lock2, time.Second), IsNil)
+	s.client.Free(lock2, true)
+}
+
+func (s *testSuite) TestLockTTLRefresh(c *C) {
+	copy := testPolicies["basic"].Copy()
+	copy.(*db.Policy).Name = "policy1"
+	c.Assert(s.client.Set(copy), IsNil)
+
+	v, err := db.CreateVolume(&db.VolumeRequest{Policy: copy.(*db.Policy), Name: "test"})
+	c.Assert(err, IsNil, Commentf("%v", v))
+	c.Assert(s.client.Set(v), IsNil)
+
+	lock := db.NewCreateOwner("mon0", v)
+	s.client.Free(lock, true)
+
+	// stopChan is sent a signal on finish of the goroutine below, this defeats a
+	// false positive in our locking system (if both channels are sent in
+	// lockstep, one will win about 50% of the time)
+	stopChan, err := s.client.AcquireAndRefresh(lock, 5*time.Second)
+	c.Assert(err, IsNil)
+
+	syncChan := make(chan struct{})
+
+	defer func() { syncChan <- struct{}{} }()
+
+	go func(v *db.Volume) {
+		for {
+			select {
+			case <-syncChan:
+				stopChan <- struct{}{}
+				return
+			default:
+				lock := db.NewCreateOwner("mon1", v)
+				c.Assert(s.client.Acquire(lock), NotNil)
+			}
+		}
+	}(v)
+
+	logrus.Info("Creating contention in etcd")
+	time.Sleep(time.Minute)
+}

--- a/db/test/policy_test.go
+++ b/db/test/policy_test.go
@@ -213,3 +213,9 @@ func (s *testSuite) TestPolicyCRUD(c *C) {
 		c.Assert(s.client.Set(testPolicies[name]), NotNil, Commentf("%v", name))
 	}
 }
+
+func (s *testSuite) TestCopy(c *C) {
+	policyCopy := testPolicies["basic"].Copy()
+	policyCopy.(*db.Policy).RuntimeOptions.UseSnapshots = false
+	c.Assert(testPolicies["basic"].RuntimeOptions.UseSnapshots, Equals, true, Commentf("runtime options pointer was not copied"))
+}

--- a/db/use.go
+++ b/db/use.go
@@ -1,0 +1,102 @@
+package db
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/contiv/errored"
+	"github.com/contiv/volplugin/errors"
+)
+
+// Use conforms to db.Lock and is used to manage volumes in volplugin.
+type Use struct {
+	Volume    string `json:"volume"`
+	UseOwner  string `json:"owner"`
+	UseReason string `json:"reason"`
+}
+
+func returnUse(reason, owner string, v *Volume) *Use {
+	return &Use{Volume: v.String(), UseOwner: owner, UseReason: reason}
+}
+
+// NewUse returns a generic use for a volume, suitable for `Get` calls via the
+// Entity interface.
+func NewUse(v *Volume) *Use {
+	return &Use{Volume: v.String()}
+}
+
+// NewCreateOwner returns a lock for a create operation on a volume.
+func NewCreateOwner(owner string, v *Volume) *Use {
+	return returnUse("Create", owner, v)
+}
+
+// NewRemoveOwner returns a lock for a remove operation on a volume.
+func NewRemoveOwner(owner string, v *Volume) *Use {
+	return returnUse("Remove", owner, v)
+}
+
+// NewMountOwner returns a properly formatted *Use. owner is typically a hostname.
+func NewMountOwner(owner string, v *Volume) *Use {
+	return returnUse("Use", owner, v)
+}
+
+// Prefix returns the path under which this data should be stored.
+func (m *Use) Prefix() string {
+	return "users/volume"
+}
+
+// Path returns the volume name.
+func (m *Use) Path() (string, error) {
+	if err := m.Validate(); err != nil {
+		return "", err
+	}
+
+	return strings.Join([]string{m.Prefix(), m.Volume}, "/"), nil
+}
+
+// Reason is the reason for taking the lock.
+func (m *Use) Reason() string {
+	return m.UseReason
+}
+
+// Owner is the owner of this lock.
+func (m *Use) Owner() string {
+	return m.UseOwner
+}
+
+// Copy copies a use and returns it.
+func (m *Use) Copy() Entity {
+	m2 := *m
+	return &m2
+}
+
+// SetKey sets the volume name from the key, and returns an error if necessary.
+func (m *Use) SetKey(key string) error {
+	m.Volume = strings.Trim(strings.TrimPrefix(key, m.Prefix()), "/")
+
+	return m.Validate()
+}
+
+// Validate does nothing on use locks.
+func (m *Use) Validate() error {
+	parts := strings.Split(m.Volume, "/")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return errors.InvalidVolume.Combine(errored.New(m.Volume))
+	}
+
+	return nil
+}
+
+func (m *Use) String() string {
+	return fmt.Sprintf("%q: owner: %q; reason %q", m.Volume, m.Owner(), m.Reason())
+}
+
+// Hooks returns an empty struct.
+func (m *Use) Hooks() *Hooks {
+	return &Hooks{}
+}
+
+// MayExist returns true for use locks.
+func (m *Use) MayExist() bool {
+	return true
+}

--- a/systemtests/init_test.go
+++ b/systemtests/init_test.go
@@ -66,9 +66,6 @@ func (s *systemtestSuite) SetUpSuite(c *C) {
 		s.mon0ip = strings.TrimSpace(ip)
 	}
 
-	c.Assert(s.clearContainers(), IsNil)
-	c.Assert(s.restartDocker(), IsNil)
-	c.Assert(s.waitDockerizedServices(), IsNil)
 	c.Assert(s.pullDebian(), IsNil)
 }
 


### PR DESCRIPTION
This implements and adds a new interface called `Lock`. Lock is presented as an
extension to Entity; one must implement a few additional methods to support it.

A few new methods were also added to acquire and free locks both with TTLs and
persistent locks.

Tests were also added for the functionality.

Signed-off-by: Erik Hollensbe <github@hollensbe.org>