### PR TITLE
api, config, db, storage, volplugin: Driver options as map[string]interface{}

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -110,7 +110,7 @@ func (a *API) GetStorageParameters(uc *Volume) (storage.MountDriver, *config.Vol
 		return nil, nil, driverOpts, err
 	}
 
-	driver, err := backend.NewMountDriver(volConfig.Backends.Mount, (*a.Global).MountPath)
+	driver, err := backend.NewMountDriver(volConfig.Backends.Mount, (*a.Global).MountPath, volConfig.DriverOptions)
 	if err != nil {
 		return nil, nil, driverOpts, errors.GetDriver.Combine(err)
 	}

--- a/api/impl/docker/docker_test.go
+++ b/api/impl/docker/docker_test.go
@@ -70,7 +70,7 @@ func (s *dockerSuite) TestBasic(c *C) {
 	err := s.client.PublishPolicy("policy1", &config.Policy{
 		Name:          "policy1",
 		Backend:       "ceph",
-		DriverOptions: map[string]string{"pool": "rbd"},
+		DriverOptions: map[string]interface{}{"pool": "rbd"},
 		CreateOptions: config.CreateOptions{
 			Size: "10MB",
 		},

--- a/config/policy.go
+++ b/config/policy.go
@@ -18,14 +18,14 @@ var defaultDrivers = map[string]*BackendDrivers{
 // Policy is the configuration of the policy. It includes default
 // information for items such as pool and volume configuration.
 type Policy struct {
-	Name           string            `json:"name"`
-	Unlocked       bool              `json:"unlocked,omitempty" merge:"unlocked"`
-	CreateOptions  CreateOptions     `json:"create"`
-	RuntimeOptions RuntimeOptions    `json:"runtime"`
-	DriverOptions  map[string]string `json:"driver"`
-	FileSystems    map[string]string `json:"filesystems"`
-	Backends       *BackendDrivers   `json:"backends,omitempty"`
-	Backend        string            `json:"backend,omitempty"`
+	Name           string                 `json:"name"`
+	Unlocked       bool                   `json:"unlocked,omitempty" merge:"unlocked"`
+	CreateOptions  CreateOptions          `json:"create"`
+	RuntimeOptions RuntimeOptions         `json:"runtime"`
+	DriverOptions  map[string]interface{} `json:"driver"`
+	FileSystems    map[string]string      `json:"filesystems"`
+	Backends       *BackendDrivers        `json:"backends,omitempty"`
+	Backend        string                 `json:"backend,omitempty"`
 }
 
 // BackendDrivers is a struct containing all the drivers used under this policy

--- a/config/policy_test.go
+++ b/config/policy_test.go
@@ -10,7 +10,7 @@ var testPolicies = map[string]*Policy{
 			Mount:    "ceph",
 			Snapshot: "ceph",
 		},
-		DriverOptions: map[string]string{"pool": "rbd"},
+		DriverOptions: map[string]interface{}{"pool": "rbd"},
 		CreateOptions: CreateOptions{
 			Size:       "10MB",
 			FileSystem: defaultFilesystem,
@@ -31,7 +31,7 @@ var testPolicies = map[string]*Policy{
 			Mount:    "ceph",
 			Snapshot: "ceph",
 		},
-		DriverOptions: map[string]string{"pool": "rbd"},
+		DriverOptions: map[string]interface{}{"pool": "rbd"},
 		CreateOptions: CreateOptions{
 			Size:       "20MB",
 			FileSystem: defaultFilesystem,
@@ -45,7 +45,7 @@ var testPolicies = map[string]*Policy{
 			Mount:    "ceph",
 			Snapshot: "ceph",
 		},
-		DriverOptions: map[string]string{"pool": "rbd"},
+		DriverOptions: map[string]interface{}{"pool": "rbd"},
 		CreateOptions: CreateOptions{
 			Size:       "0",
 			FileSystem: defaultFilesystem,
@@ -59,7 +59,7 @@ var testPolicies = map[string]*Policy{
 			Mount:    "ceph",
 			Snapshot: "ceph",
 		},
-		DriverOptions: map[string]string{"pool": "rbd"},
+		DriverOptions: map[string]interface{}{"pool": "rbd"},
 		CreateOptions: CreateOptions{
 			Size:       "20MB",
 			FileSystem: defaultFilesystem,
@@ -73,7 +73,7 @@ var testPolicies = map[string]*Policy{
 			Mount:    "ceph",
 			Snapshot: "ceph",
 		},
-		DriverOptions: map[string]string{"pool": "rbd"},
+		DriverOptions: map[string]interface{}{"pool": "rbd"},
 		CreateOptions: CreateOptions{
 			Size:       "not a number",
 			FileSystem: defaultFilesystem,
@@ -87,7 +87,7 @@ var testPolicies = map[string]*Policy{
 			Mount:    "ceph",
 			Snapshot: "ceph",
 		},
-		DriverOptions: map[string]string{"pool": "rbd"},
+		DriverOptions: map[string]interface{}{"pool": "rbd"},
 		CreateOptions: CreateOptions{
 			Size:       "10MB",
 			FileSystem: defaultFilesystem,
@@ -106,7 +106,7 @@ var testPolicies = map[string]*Policy{
 			Mount: "ceph",
 		},
 		Name:          "blanksize",
-		DriverOptions: map[string]string{"pool": "rbd"},
+		DriverOptions: map[string]interface{}{"pool": "rbd"},
 		CreateOptions: CreateOptions{
 			FileSystem: defaultFilesystem,
 		},
@@ -119,7 +119,7 @@ var testPolicies = map[string]*Policy{
 			Mount: "ceph",
 		},
 		Name:          "blanksize",
-		DriverOptions: map[string]string{"pool": "rbd"},
+		DriverOptions: map[string]interface{}{"pool": "rbd"},
 		CreateOptions: CreateOptions{
 			FileSystem: defaultFilesystem,
 		},
@@ -128,7 +128,7 @@ var testPolicies = map[string]*Policy{
 	},
 	"nobackend": {
 		Name:          "nobackend",
-		DriverOptions: map[string]string{"pool": "rbd"},
+		DriverOptions: map[string]interface{}{"pool": "rbd"},
 		CreateOptions: CreateOptions{
 			Size:       "10MB",
 			FileSystem: defaultFilesystem,

--- a/config/validation_test.go
+++ b/config/validation_test.go
@@ -7,7 +7,7 @@ var (
 	VolumeConfigs   = map[string]map[string]*Volume{
 		"valid": {
 			"basic": {
-				DriverOptions:  map[string]string{"pool": "rbd"},
+				DriverOptions:  map[string]interface{}{"pool": "rbd"},
 				CreateOptions:  CreateOptions{Size: "10MB"},
 				RuntimeOptions: RuntimeOptions{UseSnapshots: false},
 				VolumeName:     "basicvolume",
@@ -15,7 +15,7 @@ var (
 				Backends:       defaultBackends,
 			},
 			"basicwithruntime": {
-				DriverOptions:  map[string]string{"pool": "rbd"},
+				DriverOptions:  map[string]interface{}{"pool": "rbd"},
 				CreateOptions:  CreateOptions{Size: "10MB"},
 				RuntimeOptions: RuntimeOptions{UseSnapshots: true, Snapshot: SnapshotConfig{Frequency: "10m", Keep: 10}},
 				VolumeName:     "basicvolume",

--- a/config/volume.go
+++ b/config/volume.go
@@ -22,14 +22,14 @@ import (
 // Volume is the configuration of the policy. It includes pool and
 // snapshot information.
 type Volume struct {
-	PolicyName     string            `json:"policy"`
-	VolumeName     string            `json:"name"`
-	Unlocked       bool              `json:"unlocked,omitempty" merge:"unlocked"`
-	DriverOptions  map[string]string `json:"driver"`
-	MountSource    string            `json:"mount" merge:"mount"`
-	CreateOptions  CreateOptions     `json:"create"`
-	RuntimeOptions RuntimeOptions    `json:"runtime"`
-	Backends       *BackendDrivers   `json:"backends,omitempty"`
+	PolicyName     string                 `json:"policy"`
+	VolumeName     string                 `json:"name"`
+	Unlocked       bool                   `json:"unlocked,omitempty" merge:"unlocked"`
+	DriverOptions  map[string]interface{} `json:"driver"`
+	MountSource    string                 `json:"mount" merge:"mount"`
+	CreateOptions  CreateOptions          `json:"create"`
+	RuntimeOptions RuntimeOptions         `json:"runtime"`
+	Backends       *BackendDrivers        `json:"backends,omitempty"`
 }
 
 // CreateOptions are the set of options used by apiserver during the volume
@@ -102,7 +102,7 @@ func (c *Client) CreateVolume(rc *VolumeRequest) (*Volume, error) {
 	}
 
 	if resp.DriverOptions == nil {
-		resp.DriverOptions = map[string]string{}
+		resp.DriverOptions = map[string]interface{}{}
 	}
 
 	if err := resp.Validate(); err != nil {
@@ -366,7 +366,7 @@ func (cfg *Volume) validateBackends() error {
 	}
 
 	if cfg.Backends.CRUD != "" {
-		crud, err := backend.NewCRUDDriver(cfg.Backends.CRUD)
+		crud, err := backend.NewCRUDDriver(cfg.Backends.CRUD, cfg.DriverOptions)
 		if err != nil {
 			return err
 		}
@@ -376,7 +376,7 @@ func (cfg *Volume) validateBackends() error {
 		}
 	}
 
-	mnt, err := backend.NewMountDriver(cfg.Backends.Mount, backend.MountPath)
+	mnt, err := backend.NewMountDriver(cfg.Backends.Mount, backend.MountPath, cfg.DriverOptions)
 	if err != nil {
 		return err
 	}

--- a/config/volume_test.go
+++ b/config/volume_test.go
@@ -45,7 +45,7 @@ func (s *configSuite) TestVolumeValidate(c *C) {
 	c.Assert(vc.Validate(), NotNil)
 
 	vc = &Volume{
-		DriverOptions:  map[string]string{"pool": "rbd"},
+		DriverOptions:  map[string]interface{}{"pool": "rbd"},
 		CreateOptions:  CreateOptions{Size: "10MB"},
 		RuntimeOptions: RuntimeOptions{UseSnapshots: false},
 		VolumeName:     "",
@@ -55,7 +55,7 @@ func (s *configSuite) TestVolumeValidate(c *C) {
 	c.Assert(vc.Validate(), NotNil)
 
 	vc = &Volume{
-		DriverOptions:  map[string]string{"pool": "rbd"},
+		DriverOptions:  map[string]interface{}{"pool": "rbd"},
 		CreateOptions:  CreateOptions{Size: "10MB"},
 		RuntimeOptions: RuntimeOptions{UseSnapshots: false},
 		VolumeName:     "foo",
@@ -70,7 +70,7 @@ func (s *configSuite) TestVolumeValidate(c *C) {
 			Snapshot: "ceph",
 			CRUD:     "ceph",
 		},
-		DriverOptions:  map[string]string{"pool": "rbd"},
+		DriverOptions:  map[string]interface{}{"pool": "rbd"},
 		CreateOptions:  CreateOptions{Size: "10MB"},
 		RuntimeOptions: RuntimeOptions{UseSnapshots: false},
 		VolumeName:     "foo",

--- a/db/structs.go
+++ b/db/structs.go
@@ -7,14 +7,14 @@ import (
 // Policy is the configuration of the policy. It includes default
 // information for items such as pool and volume configuration.
 type Policy struct {
-	Name           string            `json:"name"`
-	Unlocked       bool              `json:"unlocked,omitempty" merge:"unlocked"`
-	CreateOptions  CreateOptions     `json:"create"`
-	RuntimeOptions *RuntimeOptions   `json:"runtime"`
-	DriverOptions  map[string]string `json:"driver"`
-	FileSystems    map[string]string `json:"filesystems"`
-	Backends       *BackendDrivers   `json:"backends,omitempty"`
-	Backend        string            `json:"backend,omitempty"`
+	Name           string                 `json:"name"`
+	Unlocked       bool                   `json:"unlocked,omitempty" merge:"unlocked"`
+	CreateOptions  CreateOptions          `json:"create"`
+	RuntimeOptions *RuntimeOptions        `json:"runtime"`
+	DriverOptions  map[string]interface{} `json:"driver"`
+	FileSystems    map[string]string      `json:"filesystems"`
+	Backends       *BackendDrivers        `json:"backends,omitempty"`
+	Backend        string                 `json:"backend,omitempty"`
 }
 
 // BackendDrivers is a struct containing all the drivers used under this policy
@@ -73,14 +73,14 @@ type UseLocker interface {
 // Volume is the configuration of the policy. It includes pool and
 // snapshot information.
 type Volume struct {
-	PolicyName     string            `json:"policy"`
-	VolumeName     string            `json:"name"`
-	Unlocked       bool              `json:"unlocked,omitempty" merge:"unlocked"`
-	DriverOptions  map[string]string `json:"driver"`
-	MountSource    string            `json:"mount" merge:"mount"`
-	CreateOptions  CreateOptions     `json:"create"`
-	RuntimeOptions *RuntimeOptions   `json:"runtime"`
-	Backends       *BackendDrivers   `json:"backends,omitempty"`
+	PolicyName     string                 `json:"policy"`
+	VolumeName     string                 `json:"name"`
+	Unlocked       bool                   `json:"unlocked,omitempty" merge:"unlocked"`
+	DriverOptions  map[string]interface{} `json:"driver"`
+	MountSource    string                 `json:"mount" merge:"mount"`
+	CreateOptions  CreateOptions          `json:"create"`
+	RuntimeOptions *RuntimeOptions        `json:"runtime"`
+	Backends       *BackendDrivers        `json:"backends,omitempty"`
 }
 
 // CreateOptions are the set of options used by apiserver during the volume

--- a/db/test/policy_test.go
+++ b/db/test/policy_test.go
@@ -13,7 +13,7 @@ var testPolicies = map[string]*db.Policy{
 			Mount:    "ceph",
 			Snapshot: "ceph",
 		},
-		DriverOptions: map[string]string{"pool": "rbd"},
+		DriverOptions: map[string]interface{}{"pool": "rbd"},
 		CreateOptions: db.CreateOptions{
 			Size:       "10MB",
 			FileSystem: db.DefaultFilesystem,
@@ -34,7 +34,7 @@ var testPolicies = map[string]*db.Policy{
 			Mount:    "ceph",
 			Snapshot: "ceph",
 		},
-		DriverOptions: map[string]string{"pool": "rbd"},
+		DriverOptions: map[string]interface{}{"pool": "rbd"},
 		CreateOptions: db.CreateOptions{
 			Size:       "20MB",
 			FileSystem: db.DefaultFilesystem,
@@ -49,7 +49,7 @@ var testPolicies = map[string]*db.Policy{
 			Mount:    "ceph",
 			Snapshot: "ceph",
 		},
-		DriverOptions: map[string]string{"pool": "rbd"},
+		DriverOptions: map[string]interface{}{"pool": "rbd"},
 		CreateOptions: db.CreateOptions{
 			Size:       "0",
 			FileSystem: db.DefaultFilesystem,
@@ -63,7 +63,7 @@ var testPolicies = map[string]*db.Policy{
 			Mount:    "ceph",
 			Snapshot: "ceph",
 		},
-		DriverOptions: map[string]string{"pool": "rbd"},
+		DriverOptions: map[string]interface{}{"pool": "rbd"},
 		CreateOptions: db.CreateOptions{
 			Size:       "not a number",
 			FileSystem: db.DefaultFilesystem,
@@ -77,7 +77,7 @@ var testPolicies = map[string]*db.Policy{
 			Mount:    "ceph",
 			Snapshot: "ceph",
 		},
-		DriverOptions: map[string]string{"pool": "rbd"},
+		DriverOptions: map[string]interface{}{"pool": "rbd"},
 		CreateOptions: db.CreateOptions{
 			Size:       "10MB",
 			FileSystem: db.DefaultFilesystem,
@@ -96,7 +96,7 @@ var testPolicies = map[string]*db.Policy{
 			Mount: "ceph",
 		},
 		Name:          "blanksize",
-		DriverOptions: map[string]string{"pool": "rbd"},
+		DriverOptions: map[string]interface{}{"pool": "rbd"},
 		CreateOptions: db.CreateOptions{
 			FileSystem: db.DefaultFilesystem,
 		},
@@ -109,7 +109,7 @@ var testPolicies = map[string]*db.Policy{
 			Mount: "ceph",
 		},
 		Name:          "blanksize",
-		DriverOptions: map[string]string{"pool": "rbd"},
+		DriverOptions: map[string]interface{}{"pool": "rbd"},
 		CreateOptions: db.CreateOptions{
 			FileSystem: db.DefaultFilesystem,
 		},
@@ -118,7 +118,7 @@ var testPolicies = map[string]*db.Policy{
 	},
 	"nobackend": {
 		Name:          "nobackend",
-		DriverOptions: map[string]string{"pool": "rbd"},
+		DriverOptions: map[string]interface{}{"pool": "rbd"},
 		CreateOptions: db.CreateOptions{
 			Size:       "10MB",
 			FileSystem: db.DefaultFilesystem,

--- a/db/test/volume_test.go
+++ b/db/test/volume_test.go
@@ -145,7 +145,7 @@ func (s *testSuite) TestVolumeValidate(c *C) {
 	c.Assert(vc.Validate(), NotNil)
 
 	vc = &db.Volume{
-		DriverOptions:  map[string]string{"pool": "rbd"},
+		DriverOptions:  map[string]interface{}{"pool": "rbd"},
 		CreateOptions:  db.CreateOptions{Size: "10MB"},
 		RuntimeOptions: &db.RuntimeOptions{UseSnapshots: false},
 		VolumeName:     "",
@@ -155,7 +155,7 @@ func (s *testSuite) TestVolumeValidate(c *C) {
 	c.Assert(vc.Validate(), NotNil)
 
 	vc = &db.Volume{
-		DriverOptions:  map[string]string{"pool": "rbd"},
+		DriverOptions:  map[string]interface{}{"pool": "rbd"},
 		CreateOptions:  db.CreateOptions{Size: "10MB"},
 		RuntimeOptions: &db.RuntimeOptions{UseSnapshots: false},
 		VolumeName:     "foo",
@@ -170,7 +170,7 @@ func (s *testSuite) TestVolumeValidate(c *C) {
 			Snapshot: "ceph",
 			CRUD:     "ceph",
 		},
-		DriverOptions:  map[string]string{"pool": "rbd"},
+		DriverOptions:  map[string]interface{}{"pool": "rbd"},
 		CreateOptions:  db.CreateOptions{Size: "10MB"},
 		RuntimeOptions: &db.RuntimeOptions{UseSnapshots: false},
 		VolumeName:     "foo",

--- a/db/volume.go
+++ b/db/volume.go
@@ -39,7 +39,7 @@ func CreateVolume(vr *VolumeRequest) (*Volume, error) {
 	}
 
 	if vr.Policy.DriverOptions == nil {
-		vr.Policy.DriverOptions = map[string]string{}
+		vr.Policy.DriverOptions = map[string]interface{}{}
 	}
 
 	if err := vr.Policy.Validate(); err != nil {
@@ -165,7 +165,7 @@ func (v *Volume) validateBackends() error {
 	}
 
 	if v.Backends.CRUD != "" {
-		crud, err := backend.NewCRUDDriver(v.Backends.CRUD)
+		crud, err := backend.NewCRUDDriver(v.Backends.CRUD, v.DriverOptions)
 		if err != nil {
 			return err
 		}
@@ -175,7 +175,7 @@ func (v *Volume) validateBackends() error {
 		}
 	}
 
-	mnt, err := backend.NewMountDriver(v.Backends.Mount, backend.MountPath)
+	mnt, err := backend.NewMountDriver(v.Backends.Mount, backend.MountPath, v.DriverOptions)
 	if err != nil {
 		return err
 	}

--- a/storage/backend/backends.go
+++ b/storage/backend/backends.go
@@ -16,13 +16,13 @@ var (
 )
 
 // MountDrivers is the map of string to storage.MountDriver.
-var MountDrivers = map[string]func(string) (storage.MountDriver, error){
+var MountDrivers = map[string]func(string, map[string]interface{}) (storage.MountDriver, error){
 	ceph.BackendName: ceph.NewMountDriver,
 	nfs.BackendName:  nfs.NewMountDriver,
 }
 
 // CRUDDrivers is the map of string to storage.CRUDDriver.
-var CRUDDrivers = map[string]func() (storage.CRUDDriver, error){
+var CRUDDrivers = map[string]func(map[string]interface{}) (storage.CRUDDriver, error){
 	ceph.BackendName: ceph.NewCRUDDriver,
 }
 
@@ -33,7 +33,7 @@ var SnapshotDrivers = map[string]func() (storage.SnapshotDriver, error){
 
 // NewMountDriver instantiates and return a mount driver instance of the
 // specified type
-func NewMountDriver(backend, mountpath string) (storage.MountDriver, error) {
+func NewMountDriver(backend, mountpath string, dOptions map[string]interface{}) (storage.MountDriver, error) {
 	f, ok := MountDrivers[backend]
 	if !ok {
 		return nil, errored.Errorf("invalid mount driver backend: %q", backend)
@@ -43,17 +43,17 @@ func NewMountDriver(backend, mountpath string) (storage.MountDriver, error) {
 		return nil, errored.Errorf("mount path not specified, cannot continue")
 	}
 
-	return f(mountpath)
+	return f(mountpath, dOptions)
 }
 
 // NewCRUDDriver instantiates a CRUD Driver.
-func NewCRUDDriver(backend string) (storage.CRUDDriver, error) {
+func NewCRUDDriver(backend string, dOptions map[string]interface{}) (storage.CRUDDriver, error) {
 	f, ok := CRUDDrivers[backend]
 	if !ok {
 		return nil, errored.Errorf("invalid CRUD driver backend: %q", backend)
 	}
 
-	return f()
+	return f(dOptions)
 }
 
 // NewSnapshotDriver creates a SnapshotDriver based on the backend name.

--- a/storage/backend/ceph/schema.go
+++ b/storage/backend/ceph/schema.go
@@ -1,0 +1,30 @@
+package ceph
+
+var (
+	// DriverOptionsSchema defines json schema for ceph driver options
+	DriverOptionsSchema = `{
+    "title": "Driver options validation",
+    "type": "object",
+    "properties": {
+      "pool": { "type": "string", "minLen": 1}
+    }
+  }`
+
+	// GlusterSchema TODO
+	GlusterSchema = `{
+    "title": "GlusterFS driverOpts validation",
+    "type": "object",
+    "properties": {
+      "replica": { "type": "number", "minimum": 1 },
+      "transport": { "type": "string", "enum": [ "tcp", "rdma" ] },
+      "stripe": { "type": "number", "minimum": 1 },
+      "bricks": {
+        "type": "object",
+        "patternProperties": {
+          ".{1,}": { "type": "string" }
+        }
+      }
+    }, 
+    "required": [ "bricks" ] 
+  }`
+)

--- a/storage/backend/ceph/util.go
+++ b/storage/backend/ceph/util.go
@@ -7,13 +7,19 @@ import (
 	"github.com/contiv/volplugin/storage"
 )
 
+// PoolName returns the 'ceph' poolName for this instance
+func (c *Driver) PoolName() string {
+	return c.dOpts.PoolName
+}
+
 // MountPath returns the path of a mount for a pool/volume.
 func (c *Driver) MountPath(do storage.DriverOptions) (string, error) {
 	volName, err := c.internalName(do.Volume.Name)
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(c.mountpath, do.Volume.Params["pool"], volName), nil
+
+	return filepath.Join(c.mountpath, c.dOpts.PoolName, volName), nil
 }
 
 // FIXME maybe this belongs in storage/ as it's more general?

--- a/storage/backend/nfs/mount.go
+++ b/storage/backend/nfs/mount.go
@@ -35,7 +35,7 @@ func (d *Driver) Mounted(timeout time.Duration) ([]*storage.Mount, error) {
 			Path:     hostMount.MountPoint,
 			Volume: storage.Volume{
 				Name: rel,
-				Params: map[string]string{
+				Params: map[string]interface{}{
 					"mount": hostMount.MountSource,
 				},
 			},

--- a/storage/backend/nfs/nfs_test.go
+++ b/storage/backend/nfs/nfs_test.go
@@ -87,7 +87,7 @@ func makeExport(c *C, name, mountArgs string) {
 }
 
 func (s *nfsSuite) TestSanity(c *C) {
-	d, err := NewMountDriver(mountPath)
+	d, err := NewMountDriver(mountPath, map[string]interface{}{})
 	c.Assert(err, IsNil)
 
 	c.Assert(d.Name(), Equals, BackendName)
@@ -110,7 +110,7 @@ func (s *nfsSuite) TestRepeatedMountSingleMountPoint(c *C) {
 		makeExport(c, "basic", "rw")
 
 		c.Assert(ioutil.WriteFile(path.Join(mkPath("basic"), "foo"), []byte{byte(i)}, 0644), IsNil)
-		d, err := NewMountDriver(mountPath)
+		d, err := NewMountDriver(mountPath, map[string]interface{}{})
 		c.Assert(err, IsNil)
 
 		vol := storage.Volume{
@@ -261,7 +261,7 @@ func (s *nfsSuite) TestMountScan(c *C) {
 	}
 
 	makeExport(c, "mountscan", "rw")
-	mountD, err := NewMountDriver(mountPath)
+	mountD, err := NewMountDriver(mountPath, map[string]interface{}{})
 	c.Assert(err, IsNil)
 
 	do := storage.DriverOptions{

--- a/storage/backend/nfs/schema.go
+++ b/storage/backend/nfs/schema.go
@@ -1,0 +1,12 @@
+package nfs
+
+var (
+	// DriverOptionsSchema defines json schema for nfs driver options
+	DriverOptionsSchema = `{  
+    "title":"Driver options validation",
+    "type":"object",
+    "properties":{  
+      "options":{ "type":"string" }
+    }
+  }`
+)

--- a/storage/control/volume.go
+++ b/storage/control/volume.go
@@ -39,7 +39,7 @@ func CreateVolume(policy *config.Policy, config *config.Volume, timeout time.Dur
 		return storage.DriverOptions{}, err
 	}
 
-	driver, err := backend.NewCRUDDriver(config.Backends.CRUD)
+	driver, err := backend.NewCRUDDriver(config.Backends.CRUD, config.DriverOptions)
 	if err != nil {
 		return storage.DriverOptions{}, err
 	}
@@ -73,7 +73,7 @@ func FormatVolume(config *config.Volume, do storage.DriverOptions) error {
 		return errors.NoActionTaken
 	}
 
-	driver, err := backend.NewCRUDDriver(config.Backends.CRUD)
+	driver, err := backend.NewCRUDDriver(config.Backends.CRUD, config.DriverOptions)
 	if err != nil {
 		return err
 	}
@@ -89,7 +89,7 @@ func ExistsVolume(config *config.Volume, timeout time.Duration) (bool, error) {
 		return true, errors.NoActionTaken
 	}
 
-	driver, err := backend.NewCRUDDriver(config.Backends.CRUD)
+	driver, err := backend.NewCRUDDriver(config.Backends.CRUD, config.DriverOptions)
 	if err != nil {
 		return false, err
 	}
@@ -112,7 +112,7 @@ func RemoveVolume(config *config.Volume, timeout time.Duration) error {
 		return errors.NoActionTaken
 	}
 
-	driver, err := backend.NewCRUDDriver(config.Backends.CRUD)
+	driver, err := backend.NewCRUDDriver(config.Backends.CRUD, config.DriverOptions)
 	if err != nil {
 		return err
 	}

--- a/storage/driver.go
+++ b/storage/driver.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"errors"
+	"strings"
 	"time"
 
 	"github.com/contiv/errored"
@@ -13,7 +14,7 @@ var (
 )
 
 // Params are parameters that relate directly to the location of the storage.
-type Params map[string]string
+type Params map[string]interface{}
 
 // A Mount is the resulting attributes of a Mount or Unmount operation.
 type Mount struct {
@@ -145,4 +146,20 @@ func (v Volume) Validate() error {
 	}
 
 	return nil
+}
+
+// Get can be used to get only "string" types from element `driver`
+func (p Params) Get(attr string, allowEmpty bool) (string, error) {
+	switch value := p[attr].(type) {
+	case string:
+		if !allowEmpty && len(strings.TrimSpace(value)) == 0 {
+			return "", errored.Errorf("Expected non-empty string for driver.%s", attr)
+		}
+		return value, nil
+	default:
+		if allowEmpty && value == nil {
+			return "", nil
+		}
+		return "", errored.Errorf("Expected string type for driver.%s", attr)
+	}
 }

--- a/storage/driver_test.go
+++ b/storage/driver_test.go
@@ -17,7 +17,7 @@ func (s *storageSuite) TestDriverOptionsValidate(c *C) {
 
 	c.Assert(do.Validate(), NotNil)
 
-	do = DriverOptions{Timeout: 1, Volume: Volume{Name: "hi", Params: map[string]string{}}}
+	do = DriverOptions{Timeout: 1, Volume: Volume{Name: "hi", Params: map[string]interface{}{}}}
 	c.Assert(do.Validate(), IsNil)
 	do.Timeout = 0
 	c.Assert(do.Validate(), NotNil)
@@ -29,13 +29,13 @@ func (s *storageSuite) TestVolumeValidate(c *C) {
 	v := Volume{}
 	c.Assert(v.Validate(), NotNil)
 
-	v = Volume{Name: "name", Size: 100, Params: map[string]string{}}
+	v = Volume{Name: "name", Size: 100, Params: map[string]interface{}{}}
 	c.Assert(v.Validate(), IsNil)
 	v.Name = ""
 	c.Assert(v.Validate(), NotNil)
 	v.Name = "name"
 	v.Params = nil
 	c.Assert(v.Validate(), NotNil)
-	v.Params = map[string]string{}
+	v.Params = map[string]interface{}{}
 	c.Assert(v.Validate(), IsNil)
 }

--- a/volplugin/init.go
+++ b/volplugin/init.go
@@ -56,7 +56,7 @@ func (dc *DaemonConfig) getMounted() (map[string]*storage.Mount, map[string]int,
 	}
 
 	for driverName := range backend.MountDrivers {
-		cd, err := backend.NewMountDriver(driverName, dc.Global.MountPath)
+		cd, err := backend.NewMountDriver(driverName, dc.Global.MountPath, map[string]interface{}{})
 		if err != nil {
 			return nil, nil, err
 		}


### PR DESCRIPTION
This will let the DriverOptions to accept any data type. Helps new storage driver integrations.

Signed-off-by: Yuva Shankar <yuva.shankar29@gmail.com>