### PR TITLE
Bind

### DIFF
--- a/ansible/roles/bind/files/resolv.conf
+++ b/ansible/roles/bind/files/resolv.conf
@@ -1,0 +1,1 @@
+nameserver 127.0.0.1

--- a/ansible/roles/bind/tasks/main.yml
+++ b/ansible/roles/bind/tasks/main.yml
@@ -1,0 +1,31 @@
+- name: install bind (redhat)
+  yum: 
+    name: bind
+    state: present
+  when: ansible_os_family == "RedHat"
+
+- name: install bind (debian)
+  apt: 
+    name: bind9
+    state: present
+  when: ansible_os_family == "Debian"
+
+- name: start/enable bind (redhat)
+  service:
+    name: named
+    enabled: true
+    state: started
+  when: ansible_os_family == "RedHat"
+
+- name: start/enable bind (debian)
+  service:
+    name: bind9
+    enabled: true
+    state: started
+  when: ansible_os_family == "Debian"
+
+- name: rewrite resolv.conf
+  copy:
+    src: resolv.conf
+    dest: /etc/resolv.conf
+

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -19,6 +19,7 @@
   become: true
   environment: '{{ env }}'
   roles: 
+  - { role: bind }
   - { role: base }
   - { role: nfs }
   - { role: vagrant }


### PR DESCRIPTION
This implements BIND as a local DNS cache on each VM. This is to ensure DNS resolution is reliable (BIND has logic to improve reliability, etc) over the test environment's services.