### PR TITLE
Makefile,Vagrantfile: remove demo mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,9 +17,6 @@ big:
 	BIG=1 vagrant up
 	make run
 
-demo:
-	DEMO=1 make restart
-
 stop:
 	vagrant destroy -f
 	make clean
@@ -75,7 +72,6 @@ unit-test-nocoverage-host:
 
 build: checks
 	vagrant ssh mon0 -c 'sudo -i sh -c "cd $(GUESTGOPATH); BUILD_VERSION=${BUILD_VERSION} make run-build"'
-	if [ ! -n "$$DEMO" ]; then for i in mon1 mon2; do vagrant ssh $$i -c 'sudo sh -c "systemctl stop volplugin apiserver volsupervisor; mkdir -p /opt/golang/bin; cp /tmp/bin/* /opt/golang/bin"'; done; fi
 
 docker: run-build
 	docker build -t contiv/volplugin .

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,17 +10,12 @@ config_file = File.expand_path(File.join(File.dirname(__FILE__), 'vagrant_variab
 ansible_config_file = File.expand_path(File.join(File.dirname(__FILE__), 'ansible', 'ansible.cfg'))
 settings = YAML.load_file(config_file)
 
-if ENV["DEMO"]
-  settings["vms"] = 1
-  settings["memory"] = 4096
-end
-
 ENV['ANSIBLE_CONFIG'] = ansible_config_file
 
 NMONS        = ENV["VMS"] || settings['vms']
 BOX          = settings['vagrant_box']
 BOX_VERSION  = settings['box_version']
-memory       = settings['memory']
+MEMORY       = settings['memory']
 
 SUBNET_PREFIX          = settings['subnet_prefix']
 SUBNET_ASSIGNMENT_DIR  = "/tmp/volplugin_vagrant_subnets/"
@@ -94,13 +89,7 @@ def random_subnet
   SUBNET_PREFIX + assigned_octet
 end
 
-SUBNET = random_subnet
-
-if ENV["BIG"]
-  memory = 8192
-end
-
-MEMORY   = memory
+SUBNET   = random_subnet
 NO_PROXY = [50,10,11,12].map { |n| "#{SUBNET}.#{n}" }.join(",")
 
 shell_provision = <<-EOF


### PR DESCRIPTION
Demo mode was a short-lived feature that ran only 1 VM. It was superceded by
run-in-containers. It is no longer needed.

Fixes #453 