### PR TITLE
build/scripts/autorun-bootstrap.sh: restore policy and global upload into autorun container image

### DIFF
--- a/build/scripts/autorun-bootstrap.sh
+++ b/build/scripts/autorun-bootstrap.sh
@@ -51,3 +51,8 @@ docker run --net host --name volplugin \
     -v /var/run/ceph:/var/run/ceph \
     -v /sys/fs/cgroup:/sys/fs/cgroup \
     contiv/volplugin volplugin
+
+sleep 5
+
+docker run -i --net host -v /run/docker/plugins:/run/docker/plugins contiv/volplugin volcli global upload </global.json
+docker run -i --net host -v /run/docker/plugins:/run/docker/plugins contiv/volplugin volcli policy upload policy1 </policy.json


### PR DESCRIPTION
The bug here is that if you use the autorun tools, the default policy and global weren't automatically uploaded. This does not line up with the documentation.