### PR TITLE
Dockerfile, Makefile, build: build changes for faster deployments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 FROM ceph/rbd
 
-COPY bin/apiserver /bin/apiserver
-COPY bin/volplugin /bin/volplugin
-COPY bin/volcli /bin/volcli
-COPY bin/volsupervisor /bin/volsupervisor
+COPY ["bin/apiserver", "bin/volplugin",  "bin/volcli", "bin/volsupervisor", "/bin/"]
+
+ENV PATH /opt/bin:$PATH
 
 ENTRYPOINT []

--- a/build/scripts/contiv-vol-run.sh
+++ b/build/scripts/contiv-vol-run.sh
@@ -4,6 +4,10 @@ if [ -f /tmp/contiv-registry ]; then
 	registry=$(cat /tmp/contiv-registry)
 fi
 
+if [ -f /tmp/contiv-bindir ]; then
+	bindir=$(cat /tmp/contiv-bindir)
+fi
+
 set -e
 
 # Check if the container already exists
@@ -48,6 +52,7 @@ case "$1" in
         -v /lib/modules:/lib/modules:ro \
         -v /var/run/docker.sock:/var/run/docker.sock \
         -v /mnt:/mnt:shared \
+        -v ${bindir}:/opt/bin:ro \
         ${registry}contiv/volplugin apiserver
     ;;
 
@@ -57,6 +62,7 @@ case "$1" in
         -v /lib/modules:/lib/modules:ro \
         -v /etc/ceph:/etc/ceph \
         -v /var/lib/ceph:/var/lib/ceph \
+        -v ${bindir}:/opt/bin:ro \
         ${registry}contiv/volplugin volsupervisor
     ;;
 
@@ -72,6 +78,7 @@ case "$1" in
         -v /var/lib/ceph:/var/lib/ceph \
         -v /var/run/ceph:/var/run/ceph \
         -v /sys/fs/cgroup:/sys/fs/cgroup \
+        -v ${bindir}:/opt/bin:ro \
         ${registry}contiv/volplugin volplugin
     ;;
 


### PR DESCRIPTION
This PR adds the support for quick reload of changes to the containers to facilitate faster testing cycles. Volplugin binaries are mapped to `/opt/bin` in the containers which is added to the top of the `PATH` in the `Dockerfile`. Any changes to the binaries here-on, reflect on a container stop-start.
- Renamed the `run-fast` target to `registry`. This is run as a part of `make start` automatically. We should not have to run this manually.
- Modified `run` target to Stop Containers, Build Code, Start Containers.
- Revamped the `build/scripts/run.sh` to support stop, start, cleanup of containers.
- Bug fix in older `run-fast` mode where we weren't passing mon0's IP to `build/scripts/run.sh` sometimes.
- Dockerfile changes to consolidate all Contiv components to a single layer.

Signed-off-by: Vikrant Balyan vijayvikrant84@gmail.com
