### PR TITLE
apiserver/daemon.go: fix bug where `volcli volume list $POLICY` showed all volumes, not just volumes belonging to the target policy.

### DIFF
--- a/apiserver/daemon.go
+++ b/apiserver/daemon.go
@@ -547,6 +547,9 @@ func (d *DaemonConfig) handleGlobal(w http.ResponseWriter, r *http.Request) {
 }
 
 func (d *DaemonConfig) handleList(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	policy := vars["policy"]
+
 	vols, err := d.Config.ListAllVolumes()
 	if err != nil {
 		api.RESTHTTPError(w, errors.ListVolume.Combine(err))
@@ -567,7 +570,9 @@ func (d *DaemonConfig) handleList(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		response = append(response, volConfig)
+		if parts[0] == policy {
+			response = append(response, volConfig)
+		}
 	}
 
 	content, err := json.Marshal(response)

--- a/systemtests/volcli_test.go
+++ b/systemtests/volcli_test.go
@@ -131,6 +131,29 @@ func (s *systemtestSuite) TestVolCLIPolicyNullDriver(c *C) {
 	c.Assert(testDriverIntent, DeepEquals, intentTarget)
 }
 
+func (s *systemtestSuite) TestVolCLIVolumeListForPolicy(c *C) {
+	out, err := s.uploadIntent("foo", "policy1")
+	c.Assert(err, IsNil, Commentf("output: %s", out))
+
+	fooVol := genRandomVolume()
+	c.Assert(s.createVolume("mon0", fqVolume("foo", fooVol), nil), IsNil)
+
+	out, err = s.uploadIntent("bar", "policy1")
+	c.Assert(err, IsNil, Commentf("output: %s", out))
+
+	barVol := genRandomVolume()
+	c.Assert(s.createVolume("mon0", fqVolume("bar", barVol), nil), IsNil)
+
+	// ensure each `volume list` command only shows the volumes belonging to the target policy
+	out, err = s.volcli("volume list foo")
+	c.Assert(err, IsNil, Commentf("output: %s", out))
+	c.Assert(strings.TrimSpace(out), Equals, fooVol)
+
+	out, err = s.volcli("volume list bar")
+	c.Assert(err, IsNil, Commentf("output: %s", out))
+	c.Assert(strings.TrimSpace(out), Equals, barVol)
+}
+
 func (s *systemtestSuite) TestVolCLIVolume(c *C) {
 	out, err := s.volcli("volume list policy1")
 	c.Assert(err, IsNil, Commentf("output: %s", out))


### PR DESCRIPTION
Fixes #461
